### PR TITLE
fix: generate() and expandQuery() fall back to local when remote unreachable

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -290,6 +290,9 @@ export class LlamaCpp implements LLM {
   // Track disposal state to prevent double-dispose
   private disposed = false;
 
+  // Cache remote server reachability to avoid retrying on every call within a process
+  private remoteEmbedDown = false;
+  private remoteLlmDown = false;
 
   constructor(config: LlamaCppConfig = {}) {
     this.embedModelUri = config.embedModel || DEFAULT_EMBED_MODEL;
@@ -563,13 +566,14 @@ export class LlamaCpp implements LLM {
 
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
     // Remote server or cloud API — preferred path
-    if (this.remoteEmbedUrl) {
+    if (this.remoteEmbedUrl && !this.remoteEmbedDown) {
       const extraParams = this.getCloudEmbedParams(!!options.isQuery);
       const result = await this.embedRemote(text, extraParams);
       if (result) return result;
       // Cloud providers don't fall back — if API key is set, the user chose cloud
       if (this.isCloudEmbedding()) return null;
-      // Local server unreachable — fall through to in-process fallback
+      // Local server unreachable — cache failure and fall through to in-process fallback
+      this.remoteEmbedDown = true;
       console.error("[embed] Remote server unreachable, falling back to in-process embedding");
     }
 
@@ -586,14 +590,15 @@ export class LlamaCpp implements LLM {
     if (texts.length === 0) return [];
 
     // Remote server or cloud API
-    if (this.remoteEmbedUrl) {
+    if (this.remoteEmbedUrl && !this.remoteEmbedDown) {
       const extraParams = this.getCloudEmbedParams(false);
       const results = await this.embedRemoteBatch(texts, extraParams);
       // If we got at least one result, remote is working
       if (results.some(r => r !== null)) return results;
       // Cloud providers don't fall back
       if (this.isCloudEmbedding()) return results;
-      // Local server unreachable — fall through to in-process fallback
+      // Local server unreachable — cache failure and fall through to in-process fallback
+      this.remoteEmbedDown = true;
       console.error("[embed] Remote server unreachable, falling back to in-process embedding");
     }
 
@@ -800,11 +805,15 @@ export class LlamaCpp implements LLM {
     const temperature = options.temperature ?? 0;
 
     // Remote LLM server (GPU) — preferred path
-    if (this.remoteLlmUrl) {
-      return this.generateRemote(prompt, maxTokens, temperature, options.signal);
+    if (this.remoteLlmUrl && !this.remoteLlmDown) {
+      const result = await this.generateRemote(prompt, maxTokens, temperature, options.signal);
+      if (result) return result;
+      // Remote server unreachable — cache failure and fall through to in-process fallback
+      this.remoteLlmDown = true;
+      console.error("[generate] Remote server unreachable, falling back to in-process generation");
     }
 
-    // Local fallback via node-llama-cpp (CPU)
+    // Local fallback via node-llama-cpp (CPU/Metal)
     await this.ensureGenerateModel();
 
     const context = await this.generateModel!.createContext();
@@ -939,8 +948,13 @@ Output:`;
     const intent = options.intent;
 
     // Remote LLM path — no grammar constraint, parse output instead
-    if (this.remoteLlmUrl) {
-      return this.expandQueryRemote(query, includeLexical, context, intent);
+    if (this.remoteLlmUrl && !this.remoteLlmDown) {
+      const result = await this.expandQueryRemote(query, includeLexical, context, intent);
+      // expandQueryRemote returns passthrough on failure, but local grammar-constrained
+      // path produces better quality — fall through if remote returned raw passthrough
+      if (result.length > 0 && result[0].text !== query) return result;
+      this.remoteLlmDown = true;
+      console.error("[expandQuery] Remote failed, falling back to in-process expansion");
     }
 
     const llama = await this.ensureLlama();


### PR DESCRIPTION
## Summary

- `generate()` now falls back to in-process `node-llama-cpp` when the remote LLM server is unreachable — matching the existing `embed()` behavior
- `expandQuery()` falls through to the local grammar-constrained expansion path instead of returning raw passthrough queries
- Remote server failures are cached per-process (`remoteEmbedDown`/`remoteLlmDown`) to avoid retrying on every call — first failure logs once, subsequent calls go directly to local

## Problem

The bash wrapper defaults `CLAWMEM_LLM_URL` to `http://localhost:8089`. When no `llama-server` is running:

- `embed()` correctly falls back to in-process embedding via `node-llama-cpp` ✅
- `generate()` calls `generateRemote()` which returns `null` on connection failure — **no local fallback** ❌
- `expandQuery()` calls `expandQueryRemote()` which returns passthrough queries — **no local fallback** ❌

This causes hooks like `decision-extractor` to silently degrade to regex extraction, and `query` to skip LLM-powered expansion entirely.

Additionally, `embed()` retries the unreachable remote server on every call within a process, producing repeated `"Remote server unreachable"` log spam (e.g., 6 times for 6 fragments in a single `update --embed`).

## Changes

Single file: `src/llm.ts`

| Method | Before | After |
|--------|--------|-------|
| `generate()` | `return this.generateRemote(...)` — no fallback | Try remote → fall through to local on failure |
| `expandQuery()` | `return this.expandQueryRemote(...)` — passthrough fallback | Try remote → fall through to local grammar-constrained expansion |
| `embed()` | Falls back but retries remote every call | Falls back + caches failure |
| `embedBatch()` | Falls back but retries remote every call | Falls back + caches failure |

## Test plan

- [ ] With `CLAWMEM_LLM_URL=http://localhost:8089` and no server running: `clawmem query "test"` uses local LLM expansion
- [ ] `decision-extractor` hook produces LLM-structured observations instead of regex fallback
- [ ] `clawmem update --embed` shows one fallback message instead of N (one per fragment)
- [ ] With a running `llama-server`: remote path still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)