### PR TITLE
Harden A-MEM parsing for noisy llama-server outputs

### DIFF
--- a/src/amem.ts
+++ b/src/amem.ts
@@ -34,6 +34,34 @@ function uniqueStrings(values: string[]): string[] {
   return out;
 }
 
+type LinkRelationType = 'semantic' | 'supporting' | 'contradicts';
+
+type ParsedLinkGeneration = {
+  target_idx: number;
+  link_type: LinkRelationType;
+  confidence: number;
+  reasoning: string;
+};
+
+
+function isLinkRelationType(value: unknown): value is LinkRelationType {
+  return value === 'semantic' || value === 'supporting' || value === 'contradicts';
+}
+
+function isUnitIntervalNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+function isParsedLinkGeneration(value: unknown): value is ParsedLinkGeneration {
+  if (!value || typeof value !== 'object') return false;
+  const link = value as Record<string, unknown>;
+  return Number.isInteger(link.target_idx) &&
+    (link.target_idx as number) > 0 &&
+    isLinkRelationType(link.link_type) &&
+    isUnitIntervalNumber(link.confidence) &&
+    typeof link.reasoning === 'string';
+}
+
 export function parseMemoryNoteFromLLM(raw: string): MemoryNote | null {
   const parsed = extractJsonFromLLM(raw) as Partial<MemoryNote> | null;
   if (parsed && Array.isArray(parsed.keywords)) {
@@ -58,37 +86,26 @@ export function parseMemoryNoteFromLLM(raw: string): MemoryNote | null {
   };
 }
 
+export function parseLinkGenerationFromLLM(raw: string): ParsedLinkGeneration[] | null {
+  const parsed = extractJsonFromLLM(raw) as { result?: unknown } | unknown[] | null;
+  const wrapped = parsed && typeof parsed === 'object' ? parsed as { result?: unknown } : null;
+  const items = Array.isArray(parsed)
+    ? parsed
+    : wrapped && Array.isArray(wrapped.result)
+      ? wrapped.result
+      : null;
 
-export function parseLinkGenerationFromLLM(raw: string): Array<{
-  target_idx: number;
-  link_type: 'semantic' | 'supporting' | 'contradicts';
-  confidence: number;
-  reasoning: string;
-}> | null {
-  const parsed = extractJsonFromLLM(raw) as Array<{
-    target_idx: number;
-    link_type: 'semantic' | 'supporting' | 'contradicts';
-    confidence: number;
-    reasoning: string;
-  }> | {
-    result?: Array<{
-      target_idx: number;
-      link_type: 'semantic' | 'supporting' | 'contradicts';
-      confidence: number;
-      reasoning: string;
-    }>;
-  } | null;
-
-  if (Array.isArray(parsed)) return parsed;
-  if (parsed && Array.isArray(parsed.result)) return parsed.result;
-  return null;
+  if (!items) return null;
+  const validItems = items.filter(isParsedLinkGeneration);
+  return validItems.length === items.length ? validItems : null;
 }
 
-
 function tryParseJsonWithCommaRepair(text: string): any | null {
-  const repaired = text
-    .replace(/(\]|\}|"(?:[^"\\]|\\.)*"|\d(?:[\d.eE+-])*)(\s*\n\s*")/g, '$1,$2')
-    .replace(/(\]|\}|"(?:[^"\\]|\\.)*"|\d(?:[\d.eE+-])*)(\s+")/g, '$1,$2');
+  // Repair missing commas between object fields without rewriting adjacent array strings.
+  const repaired = text.replace(
+    /(\]|\}|"(?:[^"\\]|\\.)*"|-?\d(?:[\d.eE+-])*|true|false|null)(\s*"[^"\n]+"\s*:)/g,
+    '$1,$2'
+  );
   if (repaired === text) return null;
   try {
     return JSON.parse(repaired);
@@ -97,25 +114,49 @@ function tryParseJsonWithCommaRepair(text: string): any | null {
   }
 }
 
+function extractBalancedJsonCandidate(text: string): string | null {
+  if (text[0] !== '{' && text[0] !== '[') return null;
 
-/**
- * Extract and parse JSON from LLM output, handling:
- * - Markdown code blocks (```json ... ```)
- * - Leading/trailing prose around JSON
- * - Truncated JSON from token limits (repairs arrays/objects)
- */
-export function extractJsonFromLLM(raw: string): any | null {
-  let text = raw.trim();
+  const stack: string[] = [text[0]!];
+  let inString = false;
+  let escaped = false;
 
-  // Strip markdown code blocks only when output starts with fenced JSON
-  if (text.startsWith('```')) {
-    const codeBlock = text.match(/```(?:json)?\s*\n?([\s\S]*?)(?:\n```|$)/);
-    if (codeBlock) {
-      text = codeBlock[1]!.trim();
+  for (let i = 1; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (ch === '{' || ch === '[') {
+      stack.push(ch);
+      continue;
+    }
+
+    if (ch === '}' || ch === ']') {
+      const expected = ch === '}' ? '{' : '[';
+      if (stack[stack.length - 1] !== expected) return null;
+      stack.pop();
+      if (stack.length === 0) return text.slice(0, i + 1);
     }
   }
 
-  // Find the first [ or { to skip leading prose
+  return null;
+}
+
+function parseJsonCandidate(raw: string): any | null {
+  let text = raw.trim();
   const arrStart = text.indexOf('[');
   const objStart = text.indexOf('{');
   if (arrStart === -1 && objStart === -1) return null;
@@ -123,17 +164,25 @@ export function extractJsonFromLLM(raw: string): any | null {
   const start = arrStart === -1 ? objStart : objStart === -1 ? arrStart : Math.min(arrStart, objStart);
   text = text.slice(start);
 
-  // Try parsing as-is first
   try {
     return JSON.parse(text);
   } catch {
-    // Try lightweight repairs before truncation handling
+    // Try extracting the first balanced JSON value before lighter repairs.
+  }
+
+  const balancedCandidate = extractBalancedJsonCandidate(text);
+  if (balancedCandidate && balancedCandidate !== text) {
+    try {
+      return JSON.parse(balancedCandidate);
+    } catch {
+      const repairedBalanced = tryParseJsonWithCommaRepair(balancedCandidate);
+      if (repairedBalanced !== null) return repairedBalanced;
+    }
   }
 
   const commaRepaired = tryParseJsonWithCommaRepair(text);
   if (commaRepaired !== null) return commaRepaired;
 
-  // Attempt truncated JSON repair
   if (text.startsWith('[')) {
     const lastBrace = text.lastIndexOf('}');
     if (lastBrace > 0) {
@@ -153,6 +202,200 @@ export function extractJsonFromLLM(raw: string): any | null {
         try { return JSON.parse(candidate); } catch { /* continue */ }
       }
     }
+  }
+
+  return null;
+}
+
+function collectFenceBlocks(text: string): Array<{ start: number; end: number; tag: string | null; body: string }> {
+  const lines = text.split('\n');
+  const fences: Array<{ start: number; end: number; tag: string | null; body: string }> = [];
+  let offset = 0;
+  let open: { start: number; tag: string | null; bodyLines: string[] } | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const lineStart = offset;
+    const lineEnd = offset + line.length;
+
+    if (!open) {
+      const match = trimmed.match(/^```([^\s`]*)?\s*$/);
+      if (match) {
+        open = { start: lineStart, tag: match[1] || null, bodyLines: [] };
+      }
+    } else if (trimmed === '```') {
+      fences.push({
+        start: open.start,
+        end: Math.min(text.length, lineEnd + 1),
+        tag: open.tag,
+        body: open.bodyLines.join('\n').trim(),
+      });
+      open = null;
+    } else {
+      open.bodyLines.push(line);
+    }
+
+    offset = lineEnd + 1;
+  }
+
+  if (open) {
+    fences.push({
+      start: open.start,
+      end: text.length,
+      tag: open.tag,
+      body: open.bodyLines.join('\n').trim(),
+    });
+  }
+
+  return fences;
+}
+
+function stripAnyFences(text: string): string {
+  const ranges = collectAnyFenceRanges(text);
+  if (ranges.length === 0) return text.trim();
+
+  let out = '';
+  let cursor = 0;
+  for (const range of ranges) {
+    out += text.slice(cursor, range.start);
+    cursor = range.end;
+  }
+  out += text.slice(cursor);
+  return out.trim();
+}
+
+function collectStructuralFences(text: string): Array<{ body: string; isJson: boolean; start: number; end: number }> {
+  return collectFenceBlocks(text)
+    .filter((fence) => fence.tag === null || fence.tag === 'json')
+    .map((fence) => ({
+      body: fence.body,
+      isJson: fence.tag === 'json',
+      start: fence.start,
+      end: fence.end,
+    }));
+}
+
+function collectAnyFenceRanges(text: string): Array<{ start: number; end: number }> {
+  return collectFenceBlocks(text).map((fence) => ({ start: fence.start, end: fence.end }));
+}
+
+function findFirstJsonStartOutsideFences(
+  text: string,
+  fences: Array<{ start: number; end: number }>
+ ): number {
+  let fenceIndex = 0;
+  for (let i = 0; i < text.length; i++) {
+    while (fenceIndex < fences.length && i >= fences[fenceIndex]!.end) {
+      fenceIndex++;
+    }
+    if (fenceIndex < fences.length) {
+      const fence = fences[fenceIndex]!;
+      if (i >= fence.start && i < fence.end) {
+        i = fence.end - 1;
+        continue;
+      }
+    }
+    if (text[i] === '[' || text[i] === '{') return i;
+  }
+  return -1;
+}
+
+function hasExampleCueBefore(text: string, index: number): boolean {
+  let end = index;
+  while (end > 0 && /\s/.test(text[end - 1]!)) end--;
+  const lineStart = text.lastIndexOf('\n', end - 1) + 1;
+  const cue = text.slice(lineStart, end).toLowerCase();
+  return cue.includes('example') || cue.includes('e.g.');
+}
+
+function hasPayloadCueBefore(text: string, index: number): boolean {
+  let end = index;
+  while (end > 0 && /\s/.test(text[end - 1]!)) end--;
+  const lineStart = text.lastIndexOf('\n', end - 1) + 1;
+  const cue = text.slice(lineStart, end).trim().toLowerCase();
+  return /^(actual|result|final|answer)(?:\s+(json|answer|response|payload))?[:\-]?$/.test(cue);
+}
+/**
+ * Extract and parse JSON from LLM output, handling:
+ * - Markdown code blocks (```json ... ```)
+ * - Leading/trailing prose around JSON
+ * - Truncated JSON from token limits (repairs arrays/objects)
+ */
+export function extractJsonFromLLM(raw: string): any | null {
+  const text = raw.trim();
+  if (!text) return null;
+
+  const fences = collectStructuralFences(text);
+  const jsonFences = fences.filter((fence) => fence.isJson);
+  const anyFenceRanges = collectAnyFenceRanges(text);
+  const outsideJsonStart = findFirstJsonStartOutsideFences(text, anyFenceRanges);
+  const outsideLooksLikeExample = outsideJsonStart !== -1 && hasExampleCueBefore(text, outsideJsonStart);
+  const outsideLooksLikePayload = outsideJsonStart !== -1 && hasPayloadCueBefore(text, outsideJsonStart);
+  const preferredJsonFences = jsonFences.filter((fence) =>
+    !hasExampleCueBefore(text, fence.start) &&
+    !(text.startsWith('```') && fence.start === fences[0]?.start && outsideLooksLikePayload)
+  );
+  const preferredUntaggedFences = fences.filter((fence) => !fence.isJson && !hasExampleCueBefore(text, fence.start));
+  const firstPreferredJsonFence = preferredJsonFences[0] ?? null;
+  const firstPreferredUntaggedFence = preferredUntaggedFences[0] ?? null;
+  const untaggedFenceLooksLikeExample = firstPreferredUntaggedFence ? hasExampleCueBefore(text, firstPreferredUntaggedFence.start) : false;
+  const tryOutsideBeforeJsonFences = outsideJsonStart !== -1 &&
+    (!firstPreferredJsonFence || outsideJsonStart < firstPreferredJsonFence.start) &&
+    !outsideLooksLikeExample;
+
+  if (text.startsWith('```') && fences[0]?.start === 0 && !outsideLooksLikePayload && (fences[0]!.isJson || preferredJsonFences.length === 0)) {
+    const parsedLeadingFence = parseJsonCandidate(fences[0]!.body);
+    if (parsedLeadingFence !== null) return parsedLeadingFence;
+  }
+
+  const tryOutsideFences = () => {
+    const withoutFences = stripAnyFences(text);
+    if (!withoutFences || withoutFences === text) return null;
+    return parseJsonCandidate(withoutFences);
+  };
+
+  if (!text.startsWith('```') && !firstPreferredJsonFence && firstPreferredUntaggedFence && outsideLooksLikeExample && !untaggedFenceLooksLikeExample) {
+    const parsedUntaggedFence = parseJsonCandidate(firstPreferredUntaggedFence.body);
+    if (parsedUntaggedFence !== null) return parsedUntaggedFence;
+  }
+
+  if (tryOutsideBeforeJsonFences) {
+    const parsedOutsideFences = tryOutsideFences();
+    if (parsedOutsideFences !== null) return parsedOutsideFences;
+  }
+
+  for (const fence of preferredJsonFences) {
+    const parsedJsonFence = parseJsonCandidate(fence.body);
+    if (parsedJsonFence !== null) return parsedJsonFence;
+  }
+
+  if (!tryOutsideBeforeJsonFences) {
+    const parsedOutsideFences = tryOutsideFences();
+    if (parsedOutsideFences !== null) return parsedOutsideFences;
+  }
+
+  if (fences.length === 0) {
+    const parsedRaw = parseJsonCandidate(text);
+    if (parsedRaw !== null) return parsedRaw;
+  }
+
+  const fallbackFences = preferredJsonFences.length === 0
+    ? [
+        ...preferredUntaggedFences,
+        ...jsonFences.filter((fence) => hasExampleCueBefore(text, fence.start)),
+        ...(text.startsWith('```')
+          ? fences.slice(1).filter((fence) => !fence.isJson && hasExampleCueBefore(text, fence.start))
+          : fences.filter((fence) => !fence.isJson && hasExampleCueBefore(text, fence.start))),
+      ]
+    : [
+        ...jsonFences.filter((fence) => hasExampleCueBefore(text, fence.start)),
+        ...(text.startsWith('```')
+          ? fences.slice(1).filter((fence) => !fence.isJson)
+          : fences.filter((fence) => !fence.isJson)),
+      ];
+  for (const fence of fallbackFences) {
+    const parsedFence = parseJsonCandidate(fence.body);
+    if (parsedFence !== null) return parsedFence;
   }
 
   return null;
@@ -370,7 +613,7 @@ Return ONLY valid JSON array in this exact format:
   }
 ]
 
-Return between 0 and ${neighbors.length} items. Use an empty JSON array [] if no meaningful links exist. Do not include explanations outside JSON.`;
+Include all ${neighbors.length} neighbors in your response.`;
 
     const result = await llm.generate(prompt, {
       temperature: 0.3,
@@ -391,22 +634,35 @@ Return between 0 and ${neighbors.length} items. Use an empty JSON array [] if no
       return 0;
     }
 
+    const expectedTargetIndexes = new Set<number>();
+    for (const link of parsed) {
+      if (link.target_idx > neighbors.length || expectedTargetIndexes.has(link.target_idx)) {
+        console.log(`[amem] RAW link generation output for docId ${docId}:`);
+        console.log(result.text);
+        console.log(`[amem] Incomplete/invalid link batch for docId ${docId}`);
+        return 0;
+      }
+      expectedTargetIndexes.add(link.target_idx);
+    }
+    if (expectedTargetIndexes.size !== neighbors.length) {
+      console.log(`[amem] RAW link generation output for docId ${docId}:`);
+      console.log(result.text);
+      console.log(`[amem] Incomplete/invalid link batch for docId ${docId}`);
+      return 0;
+    }
+
     // Insert links into memory_relations
     let linksCreated = 0;
     const now = new Date().toISOString();
 
     for (const link of parsed) {
-      // Validate link structure
-      if (typeof link.target_idx !== 'number' ||
-          link.target_idx < 1 ||
-          link.target_idx > neighbors.length ||
-          !['semantic', 'supporting', 'contradicts'].includes(link.link_type) ||
-          typeof link.confidence !== 'number') {
-        continue;
-      }
-
       const neighbor = neighbors[link.target_idx - 1];
-      if (!neighbor) continue;
+      if (!neighbor) {
+        console.log(`[amem] RAW link generation output for docId ${docId}:`);
+        console.log(result.text);
+        console.log(`[amem] Missing neighbor for validated link batch docId ${docId}`);
+        return 0;
+      }
 
       // Insert link with INSERT OR IGNORE for idempotency
       store.db.prepare(`

--- a/src/amem.ts
+++ b/src/amem.ts
@@ -59,6 +59,32 @@ export function parseMemoryNoteFromLLM(raw: string): MemoryNote | null {
 }
 
 
+export function parseLinkGenerationFromLLM(raw: string): Array<{
+  target_idx: number;
+  link_type: 'semantic' | 'supporting' | 'contradicts';
+  confidence: number;
+  reasoning: string;
+}> | null {
+  const parsed = extractJsonFromLLM(raw) as Array<{
+    target_idx: number;
+    link_type: 'semantic' | 'supporting' | 'contradicts';
+    confidence: number;
+    reasoning: string;
+  }> | {
+    result?: Array<{
+      target_idx: number;
+      link_type: 'semantic' | 'supporting' | 'contradicts';
+      confidence: number;
+      reasoning: string;
+    }>;
+  } | null;
+
+  if (Array.isArray(parsed)) return parsed;
+  if (parsed && Array.isArray(parsed.result)) return parsed.result;
+  return null;
+}
+
+
 function tryParseJsonWithCommaRepair(text: string): any | null {
   const repaired = text
     .replace(/(\]|\}|"(?:[^"\\]|\\.)*"|\d(?:[\d.eE+-])*)(\s*\n\s*")/g, '$1,$2')
@@ -356,14 +382,9 @@ Return between 0 and ${neighbors.length} items. Use an empty JSON array [] if no
       return 0;
     }
 
-    const parsed = extractJsonFromLLM(result.text) as Array<{
-      target_idx: number;
-      link_type: 'semantic' | 'supporting' | 'contradicts';
-      confidence: number;
-      reasoning: string;
-    }> | null;
+    const parsed = parseLinkGenerationFromLLM(result.text);
 
-    if (!Array.isArray(parsed)) {
+    if (!parsed) {
       console.log(`[amem] RAW link generation output for docId ${docId}:`);
       console.log(result.text);
       console.log(`[amem] Invalid/unparseable JSON for link generation docId ${docId}`);

--- a/src/amem.ts
+++ b/src/amem.ts
@@ -155,29 +155,95 @@ function extractBalancedJsonCandidate(text: string): string | null {
   return null;
 }
 
+function parseBalancedJsonValue(candidate: string): any | null {
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    return tryParseJsonWithCommaRepair(candidate);
+  }
+}
+
+function jsonStartsAtTrimmedLineStart(text: string, index: number): boolean {
+  const lineStart = text.lastIndexOf('\n', index - 1) + 1;
+  return text.slice(lineStart, index).trim().length === 0;
+}
+
+function findLineStartJsonAfter(text: string, index: number): number {
+  for (let i = index; i < text.length; i++) {
+    if ((text[i] === '{' || text[i] === '[') && jsonStartsAtTrimmedLineStart(text, i)) return i;
+  }
+  return -1;
+}
+
+function isLikelyInlineProseLiteral(text: string, index: number): boolean {
+  return !jsonStartsAtTrimmedLineStart(text, index) && !hasPayloadCueBefore(text, index);
+}
+
+function collectParseableBalancedJsonCandidates(
+  text: string,
+  startIndex: number
+): Array<{ start: number; parsed: any }> {
+  const candidates: Array<{ start: number; parsed: any }> = [];
+  for (let i = startIndex; i < text.length; i++) {
+    if (text[i] !== '{' && text[i] !== '[') continue;
+
+    const balancedCandidate = extractBalancedJsonCandidate(text.slice(i));
+    if (!balancedCandidate) continue;
+
+    const parsed = parseBalancedJsonValue(balancedCandidate);
+    if (parsed !== null) candidates.push({ start: i, parsed });
+
+    i += balancedCandidate.length - 1;
+  }
+  return candidates;
+}
+
+function selectBalancedJsonCandidate(text: string, candidates: Array<{ start: number; parsed: any }>): any | null {
+  if (candidates.length === 0) return null;
+
+  const payloadCandidate = candidates.find((candidate) => hasPayloadCueBefore(text, candidate.start));
+  if (payloadCandidate) return payloadCandidate.parsed;
+
+  const first = candidates[0]!;
+  if (candidates.length > 1 && (hasExampleCueBefore(text, first.start) || isLikelyInlineProseLiteral(text, first.start))) {
+    const laterPayload = candidates.find((candidate) =>
+      !hasExampleCueBefore(text, candidate.start) && !isLikelyInlineProseLiteral(text, candidate.start)
+    );
+    if (laterPayload) return laterPayload.parsed;
+  }
+
+  return first.parsed;
+}
+
 function parseJsonCandidate(raw: string): any | null {
-  let text = raw.trim();
-  const arrStart = text.indexOf('[');
-  const objStart = text.indexOf('{');
+  const trimmed = raw.trim();
+  const arrStart = trimmed.indexOf('[');
+  const objStart = trimmed.indexOf('{');
   if (arrStart === -1 && objStart === -1) return null;
 
   const start = arrStart === -1 ? objStart : objStart === -1 ? arrStart : Math.min(arrStart, objStart);
-  text = text.slice(start);
+  const text = trimmed.slice(start);
 
   try {
     return JSON.parse(text);
   } catch {
-    // Try extracting the first balanced JSON value before lighter repairs.
+    // Try extracting balanced JSON values before lighter repairs.
   }
 
-  const balancedCandidate = extractBalancedJsonCandidate(text);
-  if (balancedCandidate && balancedCandidate !== text) {
-    try {
-      return JSON.parse(balancedCandidate);
-    } catch {
-      const repairedBalanced = tryParseJsonWithCommaRepair(balancedCandidate);
-      if (repairedBalanced !== null) return repairedBalanced;
+  const firstBalancedCandidate = extractBalancedJsonCandidate(text);
+  if (firstBalancedCandidate) {
+    if (hasExampleCueBefore(trimmed, start) || isLikelyInlineProseLiteral(trimmed, start)) {
+      const laterLineStartJson = findLineStartJsonAfter(trimmed, start + firstBalancedCandidate.length);
+      if (laterLineStartJson !== -1) {
+        const laterParsed = parseJsonCandidate(trimmed.slice(laterLineStartJson));
+        if (laterParsed !== null) return laterParsed;
+      }
     }
+    const balancedParsed = selectBalancedJsonCandidate(
+      trimmed,
+      collectParseableBalancedJsonCandidates(trimmed, start)
+    );
+    if (balancedParsed !== null) return balancedParsed;
   }
 
   const commaRepaired = tryParseJsonWithCommaRepair(text);
@@ -305,7 +371,7 @@ function hasExampleCueBefore(text: string, index: number): boolean {
   while (end > 0 && /\s/.test(text[end - 1]!)) end--;
   const lineStart = text.lastIndexOf('\n', end - 1) + 1;
   const cue = text.slice(lineStart, end).toLowerCase();
-  return cue.includes('example') || cue.includes('e.g.');
+  return cue.includes('example') || cue.includes('e.g.') || cue.includes('schema');
 }
 
 function hasPayloadCueBefore(text: string, index: number): boolean {
@@ -339,9 +405,10 @@ export function extractJsonFromLLM(raw: string): any | null {
   const firstPreferredJsonFence = preferredJsonFences[0] ?? null;
   const firstPreferredUntaggedFence = preferredUntaggedFences[0] ?? null;
   const untaggedFenceLooksLikeExample = firstPreferredUntaggedFence ? hasExampleCueBefore(text, firstPreferredUntaggedFence.start) : false;
+  const outsidePrecedesPreferredJsonFence = !!firstPreferredJsonFence && outsideJsonStart < firstPreferredJsonFence.start;
   const tryOutsideBeforeJsonFences = outsideJsonStart !== -1 &&
-    (!firstPreferredJsonFence || outsideJsonStart < firstPreferredJsonFence.start) &&
-    !outsideLooksLikeExample;
+    !outsideLooksLikeExample &&
+    (!outsidePrecedesPreferredJsonFence || outsideLooksLikePayload);
 
   if (text.startsWith('```') && fences[0]?.start === 0 && !outsideLooksLikePayload && (fences[0]!.isJson || preferredJsonFences.length === 0)) {
     const parsedLeadingFence = parseJsonCandidate(fences[0]!.body);
@@ -634,35 +701,23 @@ Include all ${neighbors.length} neighbors in your response.`;
       return 0;
     }
 
-    const expectedTargetIndexes = new Set<number>();
-    for (const link of parsed) {
-      if (link.target_idx > neighbors.length || expectedTargetIndexes.has(link.target_idx)) {
-        console.log(`[amem] RAW link generation output for docId ${docId}:`);
-        console.log(result.text);
-        console.log(`[amem] Incomplete/invalid link batch for docId ${docId}`);
-        return 0;
-      }
-      expectedTargetIndexes.add(link.target_idx);
-    }
-    if (expectedTargetIndexes.size !== neighbors.length) {
-      console.log(`[amem] RAW link generation output for docId ${docId}:`);
-      console.log(result.text);
-      console.log(`[amem] Incomplete/invalid link batch for docId ${docId}`);
-      return 0;
-    }
 
     // Insert links into memory_relations
     let linksCreated = 0;
     const now = new Date().toISOString();
+    const linkedTargetIndexes = new Set<number>();
 
     for (const link of parsed) {
       const neighbor = neighbors[link.target_idx - 1];
       if (!neighbor) {
-        console.log(`[amem] RAW link generation output for docId ${docId}:`);
-        console.log(result.text);
-        console.log(`[amem] Missing neighbor for validated link batch docId ${docId}`);
-        return 0;
+        console.log(`[amem] Skipping out-of-range link target ${link.target_idx} for docId ${docId}`);
+        continue;
       }
+      if (linkedTargetIndexes.has(link.target_idx)) {
+        console.log(`[amem] Skipping duplicate link target ${link.target_idx} for docId ${docId}`);
+        continue;
+      }
+      linkedTargetIndexes.add(link.target_idx);
 
       // Insert link with INSERT OR IGNORE for idempotency
       store.db.prepare(`

--- a/src/amem.ts
+++ b/src/amem.ts
@@ -22,6 +22,56 @@ const EMPTY_NOTE: MemoryNote = {
   context: ""
 };
 
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+export function parseMemoryNoteFromLLM(raw: string): MemoryNote | null {
+  const parsed = extractJsonFromLLM(raw) as Partial<MemoryNote> | null;
+  if (parsed && Array.isArray(parsed.keywords)) {
+    return {
+      keywords: parsed.keywords.filter((v): v is string => typeof v === 'string'),
+      tags: Array.isArray(parsed.tags) ? parsed.tags.filter((v): v is string => typeof v === 'string') : [],
+      context: typeof parsed.context === 'string' ? parsed.context : '',
+    };
+  }
+
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const keywords = uniqueStrings(lines.filter((line) => line.startsWith('lex:')).map((line) => line.slice(4).trim()));
+  const context = lines.find((line) => line.startsWith('hyde:'))?.slice(5).trim() ?? '';
+  if (keywords.length === 0 && !context) {
+    return null;
+  }
+
+  return {
+    keywords,
+    tags: [],
+    context,
+  };
+}
+
+
+function tryParseJsonWithCommaRepair(text: string): any | null {
+  const repaired = text
+    .replace(/(\]|\}|"(?:[^"\\]|\\.)*"|\d(?:[\d.eE+-])*)(\s*\n\s*")/g, '$1,$2')
+    .replace(/(\]|\}|"(?:[^"\\]|\\.)*"|\d(?:[\d.eE+-])*)(\s+")/g, '$1,$2');
+  if (repaired === text) return null;
+  try {
+    return JSON.parse(repaired);
+  } catch {
+    return null;
+  }
+}
+
+
 /**
  * Extract and parse JSON from LLM output, handling:
  * - Markdown code blocks (```json ... ```)
@@ -31,10 +81,12 @@ const EMPTY_NOTE: MemoryNote = {
 export function extractJsonFromLLM(raw: string): any | null {
   let text = raw.trim();
 
-  // Strip markdown code blocks
-  const codeBlock = text.match(/```(?:json)?\s*\n?([\s\S]*?)(?:\n```|$)/);
-  if (codeBlock) {
-    text = codeBlock[1]!.trim();
+  // Strip markdown code blocks only when output starts with fenced JSON
+  if (text.startsWith('```')) {
+    const codeBlock = text.match(/```(?:json)?\s*\n?([\s\S]*?)(?:\n```|$)/);
+    if (codeBlock) {
+      text = codeBlock[1]!.trim();
+    }
   }
 
   // Find the first [ or { to skip leading prose
@@ -49,23 +101,23 @@ export function extractJsonFromLLM(raw: string): any | null {
   try {
     return JSON.parse(text);
   } catch {
-    // Attempt truncated JSON repair
+    // Try lightweight repairs before truncation handling
   }
 
-  // Repair truncated arrays: find last complete object, close the array
+  const commaRepaired = tryParseJsonWithCommaRepair(text);
+  if (commaRepaired !== null) return commaRepaired;
+
+  // Attempt truncated JSON repair
   if (text.startsWith('[')) {
     const lastBrace = text.lastIndexOf('}');
     if (lastBrace > 0) {
       const repaired = text.slice(0, lastBrace + 1) + ']';
       try { return JSON.parse(repaired); } catch { /* continue */ }
     }
-    // Might be an empty or trivial array
     try { return JSON.parse(text.replace(/,\s*$/, '') + ']'); } catch { /* continue */ }
   }
 
-  // Repair truncated objects: find last complete value, close the object
   if (text.startsWith('{')) {
-    // Try closing at each } from the end
     for (let i = text.length - 1; i > 0; i--) {
       if (text[i] === '}' || text[i] === '"' || text[i] === '0' || text[i] === '1' ||
           text[i] === '2' || text[i] === '3' || text[i] === '4' || text[i] === '5' ||
@@ -142,9 +194,11 @@ Return ONLY valid JSON in this exact format:
       return EMPTY_NOTE;
     }
 
-    const parsed = extractJsonFromLLM(result.text) as MemoryNote | null;
+    const parsed = parseMemoryNoteFromLLM(result.text);
 
-    if (!parsed || !Array.isArray(parsed.keywords) || !Array.isArray(parsed.tags) || typeof parsed.context !== 'string') {
+    if (!parsed) {
+      console.log(`[amem] RAW memory note output for docId ${docId}:`);
+      console.log(result.text);
       console.log(`[amem] Invalid/unparseable JSON for docId ${docId}`);
       return EMPTY_NOTE;
     }
@@ -290,7 +344,7 @@ Return ONLY valid JSON array in this exact format:
   }
 ]
 
-Include all ${neighbors.length} neighbors in your response.`;
+Return between 0 and ${neighbors.length} items. Use an empty JSON array [] if no meaningful links exist. Do not include explanations outside JSON.`;
 
     const result = await llm.generate(prompt, {
       temperature: 0.3,
@@ -310,6 +364,8 @@ Include all ${neighbors.length} neighbors in your response.`;
     }> | null;
 
     if (!Array.isArray(parsed)) {
+      console.log(`[amem] RAW link generation output for docId ${docId}:`);
+      console.log(result.text);
       console.log(`[amem] Invalid/unparseable JSON for link generation docId ${docId}`);
       return 0;
     }

--- a/tests/unit/amem.test.ts
+++ b/tests/unit/amem.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
-import { extractJsonFromLLM, parseMemoryNoteFromLLM } from "../../src/amem.ts";
+
+import { extractJsonFromLLM, parseLinkGenerationFromLLM, parseMemoryNoteFromLLM } from "../../src/amem.ts";
 
 // ─── extractJsonFromLLM ─────────────────────────────────────────────
 
@@ -107,5 +108,20 @@ describe("parseMemoryNoteFromLLM repair", () => {
       tags: ["tag1", "tag2"],
       context: "Brief summary",
     });
+  });
+});
+
+describe("parseLinkGenerationFromLLM", () => {
+  it("unwraps object-wrapped result arrays", () => {
+    const raw = `{"status":"valid","confidence":0.95,"result":[{"target_idx":1,"link_type":"semantic","confidence":0.85,"reasoning":"Brief explanation"}]}`;
+    const result = parseLinkGenerationFromLLM(raw);
+    expect(result).toEqual([
+      {
+        target_idx: 1,
+        link_type: "semantic",
+        confidence: 0.85,
+        reasoning: "Brief explanation",
+      },
+    ]);
   });
 });

--- a/tests/unit/amem.test.ts
+++ b/tests/unit/amem.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 
-import { extractJsonFromLLM, parseLinkGenerationFromLLM, parseMemoryNoteFromLLM } from "../../src/amem.ts";
+import { extractJsonFromLLM, generateMemoryLinks, parseLinkGenerationFromLLM, parseMemoryNoteFromLLM } from "../../src/amem.ts";
+import { createTestStore, seedDocuments } from "../helpers/test-store.ts";
 
 // ─── extractJsonFromLLM ─────────────────────────────────────────────
 
@@ -181,6 +182,29 @@ describe("extractJsonFromLLM", () => {
     const result = extractJsonFromLLM(raw);
     expect(result).toEqual([{ key: "value" }]);
   });
+
+  it("prefers fenced payloads over earlier prose bracket literals", () => {
+    const raw = 'Return empty array [] if no structured facts found.\n```json\n[{"title":"T","contentType":"decision","narrative":"N"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ title: "T", contentType: "decision", narrative: "N" }]);
+  });
+
+  it("prefers fenced payloads when the conversation-synthesis prompt is echoed first", () => {
+    const raw = [
+      "The instruction was: Return ONLY valid JSON array. Return empty array [] if no structured facts found.",
+      "```json",
+      '[{"title":"T","contentType":"decision","narrative":"N"}]',
+      "```",
+    ].join("\n");
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ title: "T", contentType: "decision", narrative: "N" }]);
+  });
+
+  it("prefers later raw payloads over earlier prose schema literals", () => {
+    const raw = 'Schema: {"target_idx":1,"link_type":"semantic","confidence":0.9,"reasoning":"example"}\n[{"target_idx":1,"link_type":"semantic","confidence":0.8,"reasoning":"real"}]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ target_idx: 1, link_type: "semantic", confidence: 0.8, reasoning: "real" }]);
+  });
 });
 
 describe("parseMemoryNoteFromLLM", () => {
@@ -293,5 +317,76 @@ describe("parseLinkGenerationFromLLM", () => {
         reasoning: "one",
       },
     ]);
+  });
+
+  it("parses real link arrays after prose schema examples", () => {
+    const raw = 'Schema: {"target_idx":1,"link_type":"semantic","confidence":0.9,"reasoning":"example"}\n[{"target_idx":1,"link_type":"semantic","confidence":0.8,"reasoning":"real"}]';
+    const result = parseLinkGenerationFromLLM(raw);
+    expect(result).toEqual([
+      {
+        target_idx: 1,
+        link_type: "semantic",
+        confidence: 0.8,
+        reasoning: "real",
+      },
+    ]);
+  });
+});
+
+describe("generateMemoryLinks", () => {
+  it("inserts valid partial link batches instead of requiring all neighbors", async () => {
+    const store = createTestStore();
+    try {
+      const ids = seedDocuments(store, [
+        { path: "source.md", title: "Source", body: "source" },
+        { path: "n1.md", title: "Neighbor 1", body: "one" },
+        { path: "n2.md", title: "Neighbor 2", body: "two" },
+        { path: "n3.md", title: "Neighbor 3", body: "three" },
+        { path: "n4.md", title: "Neighbor 4", body: "four" },
+        { path: "n5.md", title: "Neighbor 5", body: "five" },
+      ]);
+
+      store.db.prepare("UPDATE documents SET amem_context = title").run();
+      store.ensureVecTable(2);
+
+      const rows = store.db.prepare("SELECT id, hash FROM documents ORDER BY id").all() as Array<{ id: number; hash: string }>;
+      const embeddings = new Map<number, [number, number]>([
+        [ids[0]!, [1, 0]],
+        [ids[1]!, [0.99, 0.01]],
+        [ids[2]!, [0.98, 0.02]],
+        [ids[3]!, [0.97, 0.03]],
+        [ids[4]!, [0.96, 0.04]],
+        [ids[5]!, [0.95, 0.05]],
+      ]);
+
+      for (const row of rows) {
+        const embedding = embeddings.get(row.id);
+        if (!embedding) throw new Error(`missing embedding for doc ${row.id}`);
+        store.insertEmbedding(row.hash, 0, 0, new Float32Array(embedding), "test", new Date().toISOString());
+      }
+
+      const llm = {
+        generate: async () => ({
+          text: JSON.stringify([
+            { target_idx: 1, link_type: "semantic", confidence: 0.8, reasoning: "one" },
+            { target_idx: 2, link_type: "supporting", confidence: 0.7, reasoning: "two" },
+            { target_idx: 3, link_type: "semantic", confidence: 0.6, reasoning: "three" },
+            { target_idx: 4, link_type: "contradicts", confidence: 0.5, reasoning: "four" },
+            { target_idx: 2, link_type: "contradicts", confidence: 0.9, reasoning: "duplicate" },
+            { target_idx: 99, link_type: "semantic", confidence: 0.4, reasoning: "out of range" },
+          ]),
+        }),
+      };
+
+      const created = await generateMemoryLinks(store, llm as any, ids[0]!, 5);
+      expect(created).toBe(4);
+
+      const relationCount = store.db.prepare(
+        "SELECT COUNT(*) as count FROM memory_relations WHERE source_id = ?"
+      ).get(ids[0]!) as { count: number };
+      expect(relationCount.count).toBe(4);
+    } finally {
+      store.close();
+    }
   });
 });

--- a/tests/unit/amem.test.ts
+++ b/tests/unit/amem.test.ts
@@ -61,6 +61,126 @@ describe("extractJsonFromLLM", () => {
     const result = extractJsonFromLLM(raw);
     expect(result).toEqual([{ key: "value" }]);
   });
+
+  it("parses prose-prefixed fenced empty arrays", () => {
+    const raw = 'Here is the JSON:\n```json\n[]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([]);
+  });
+
+  it("does not treat literal triple backticks inside JSON strings as fences", () => {
+    const raw = '{"context":"Use ```json code fences``` in docs."}';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual({ context: "Use ```json code fences``` in docs." });
+  });
+
+  it("does not repair adjacent array strings as object fields", () => {
+    const raw = '[\n  "alpha"\n  "beta"\n]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toBeNull();
+  });
+
+  it("prefers later fenced JSON payloads after prose examples", () => {
+    const raw = 'Example:\n```\n[]\n```\nActual:\n```json\n[{"key":"value"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("keeps the leading fenced payload when later examples follow", () => {
+    const raw = '```json\n[{"key":"value"}]\n```\nExample:\n```\n[]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("prefers the first json fence when later fenced examples follow prose", () => {
+    const raw = 'Here is the result:\n```json\n[{"key":"value"}]\n```\nExample:\n```\n[]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("does not let later raw JSON examples override a leading fenced payload", () => {
+    const raw = '```json\n[{"key":"value"}]\n```\nExample: [{"key":"example"}]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("prefers raw JSON before later json-fenced examples", () => {
+    const raw = 'Result:\n[]\nExample:\n```json\n[{"key":"example"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([]);
+  });
+
+  it("prefers later json fences over leading untagged examples", () => {
+    const raw = '```\n[]\n```\nActual:\n```json\n[{"key":"value"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("keeps the first untagged fence when later untagged examples follow prose", () => {
+    const raw = 'Result:\n```\n[]\n```\nExample:\n```\n[{"key":"example"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([]);
+  });
+
+  it("keeps the first untagged fence when later raw examples follow prose", () => {
+    const raw = 'Here is the result:\n```\n[{"key":"value"}]\n```\nExample: [{"key":"example"}]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("prefers later json payloads over earlier example json fences", () => {
+    const raw = 'Example:\n```json\n[]\n```\nActual:\n```json\n[{"key":"value"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("extracts balanced raw JSON before trailing prose", () => {
+    const raw = '[{"key":"value"}]\nAdditional explanation follows.';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("prefers later raw payloads over leading fenced examples", () => {
+    const raw = '```json\n[]\n```\nActual:\n[{"key":"value"}]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("prefers later untagged payloads over earlier json-fenced examples", () => {
+    const raw = 'Example:\n```json\n[]\n```\nActual:\n```\n[{"key":"value"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("ignores tagged code fences when finding outside JSON", () => {
+    const raw = '```ts\nconst result = [{"key":"example"}];\n```\nActual:\n```json\n[{"key":"value"}]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("prefers raw payloads after leading tagged example fences", () => {
+    const raw = '```ts\nconst result = [{"key":"example"}];\n```\n[{"key":"real"}]\nExample:\n```json\n[]\n```';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "real" }]);
+  });
+
+  it("recognizes final answer cues as payload markers", () => {
+    const raw = '```json\n[]\n```\nFinal answer:\n[{"key":"value"}]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("recognizes answer cues as payload markers", () => {
+    const raw = '```json\n[]\n```\nAnswer:\n[{"key":"value"}]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
+
+  it("does not treat descriptive schema prose as a payload cue", () => {
+    const raw = '```json\n[{"key":"value"}]\n```\nThe result schema is [{"key":"example"}]';
+    const result = extractJsonFromLLM(raw);
+    expect(result).toEqual([{ key: "value" }]);
+  });
 });
 
 describe("parseMemoryNoteFromLLM", () => {
@@ -121,6 +241,56 @@ describe("parseLinkGenerationFromLLM", () => {
         link_type: "semantic",
         confidence: 0.85,
         reasoning: "Brief explanation",
+      },
+    ]);
+  });
+
+  it("accepts the primary bare-array payload shape", () => {
+    const raw = `[{"target_idx":1,"link_type":"semantic","confidence":0.85,"reasoning":"Brief explanation"}]`;
+    const result = parseLinkGenerationFromLLM(raw);
+    expect(result).toEqual([
+      {
+        target_idx: 1,
+        link_type: "semantic",
+        confidence: 0.85,
+        reasoning: "Brief explanation",
+      },
+    ]);
+  });
+
+  it("rejects malformed link items after unwrapping result arrays", () => {
+    const raw = `{"result":[{"target_idx":1,"link_type":"semantic","confidence":0.85,"reasoning":"Brief explanation"},{"target_idx":2,"link_type":"semantic","confidence":0.8},{"target_idx":3,"link_type":"semantic","confidence":0.75,"reasoning":4}]}`;
+    const result = parseLinkGenerationFromLLM(raw);
+    expect(result).toBeNull();
+  });
+
+  it("rejects non-finite and out-of-range confidences", () => {
+    const raw = `{"result":[{"target_idx":1,"link_type":"semantic","confidence":1e309,"reasoning":"overflow"},{"target_idx":2,"link_type":"semantic","confidence":-0.1,"reasoning":"negative"},{"target_idx":3,"link_type":"semantic","confidence":1.1,"reasoning":"too high"},{"target_idx":4,"link_type":"semantic","confidence":0.5,"reasoning":"valid"}]}`;
+    const result = parseLinkGenerationFromLLM(raw);
+    expect(result).toBeNull();
+  });
+
+  it("rejects invalid target indexes", () => {
+    const raw = `{"result":[{"target_idx":0,"link_type":"semantic","confidence":0.5,"reasoning":"zero"},{"target_idx":1.5,"link_type":"semantic","confidence":0.5,"reasoning":"fractional"},{"target_idx":2,"link_type":"semantic","confidence":0.5,"reasoning":"valid"}]}`;
+    const result = parseLinkGenerationFromLLM(raw);
+    expect(result).toBeNull();
+  });
+
+  it("accepts inclusive confidence boundaries", () => {
+    const raw = `{"result":[{"target_idx":1,"link_type":"semantic","confidence":0,"reasoning":"zero"},{"target_idx":2,"link_type":"semantic","confidence":1,"reasoning":"one"}]}`;
+    const result = parseLinkGenerationFromLLM(raw);
+    expect(result).toEqual([
+      {
+        target_idx: 1,
+        link_type: "semantic",
+        confidence: 0,
+        reasoning: "zero",
+      },
+      {
+        target_idx: 2,
+        link_type: "semantic",
+        confidence: 1,
+        reasoning: "one",
       },
     ]);
   });

--- a/tests/unit/amem.test.ts
+++ b/tests/unit/amem.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { extractJsonFromLLM } from "../../src/amem.ts";
+import { extractJsonFromLLM, parseMemoryNoteFromLLM } from "../../src/amem.ts";
 
 // ─── extractJsonFromLLM ─────────────────────────────────────────────
 
@@ -59,5 +59,53 @@ describe("extractJsonFromLLM", () => {
     const raw = '```json\n[{"key": "value"}]';
     const result = extractJsonFromLLM(raw);
     expect(result).toEqual([{ key: "value" }]);
+  });
+});
+
+describe("parseMemoryNoteFromLLM", () => {
+  it("salvages partial JSON missing tags and context", () => {
+    const raw = '```json\n{"keywords":["scheduled reports design"]}\n```';
+    const result = parseMemoryNoteFromLLM(raw);
+    expect(result).toEqual({
+      keywords: ["scheduled reports design"],
+      tags: [],
+      context: "",
+    });
+  });
+
+  it("salvages lex vec hyde fallback output", () => {
+    const raw = [
+      'lex: scheduled reports v2 design',
+      'lex: scheduled reports v2 documentation',
+      'vec: scheduled reports v2 design pattern implementation',
+      'hyde: Here are some code examples for scheduled reports v2.',
+    ].join('\n');
+    const result = parseMemoryNoteFromLLM(raw);
+    expect(result).toEqual({
+      keywords: [
+        'scheduled reports v2 design',
+        'scheduled reports v2 documentation',
+      ],
+      tags: [],
+      context: 'Here are some code examples for scheduled reports v2.',
+    });
+  });
+});
+
+describe("parseMemoryNoteFromLLM repair", () => {
+  it("repairs missing commas between top-level object fields", () => {
+    const raw = [
+      '{',
+      '  "keywords": ["scheduled reports design"]',
+      '  "tags": ["tag1", "tag2"]',
+      '  "context": "Brief summary"',
+      '}',
+    ].join('\n');
+    const result = parseMemoryNoteFromLLM(raw);
+    expect(result).toEqual({
+      keywords: ["scheduled reports design"],
+      tags: ["tag1", "tag2"],
+      context: "Brief summary",
+    });
   });
 });


### PR DESCRIPTION
# Harden A-MEM parsing for noisy llama-server outputs

## Summary
This patch makes A-MEM enrichment more tolerant of malformed-but-salvageable model outputs observed from the documented remote `CLAWMEM_LLM_URL` path.

Changes in `src/amem.ts`:
- only strip fenced code blocks when the response actually starts with ```
- add lightweight missing-comma repair in `extractJsonFromLLM()` for top-level object fields
- add `parseMemoryNoteFromLLM()` to salvage:
  - partial JSON missing `tags` / `context`
  - `lex:/vec:/hyde:` fallback-style outputs from the 8089 model
- switch `constructMemoryNote()` to use the new salvage helper instead of strict object rejection
- add `parseLinkGenerationFromLLM()` to unwrap object-wrapped link arrays such as `{ status, confidence, result: [...] }`
- switch link generation to use the new unwrap helper instead of requiring a top-level array only

## Repro
Environment:
- local `llama-server` on 8088 / 8089 / 8090
- `CLAWMEM_LLM_URL=http://127.0.0.1:8089`
- `CLAWMEM_EMBED_URL=http://127.0.0.1:8088`
- `CLAWMEM_RERANK_URL=http://127.0.0.1:8090`

Before patch, `clawmem reindex --enrich` intermittently logged:
- `Invalid/unparseable JSON for link generation docId ...`
- `Invalid/unparseable JSON for docId ...`

Captured raw failing outputs included:

### Link generation sample 1
```text
"""
[
  {
    "target_idx": 1,
    "link_type": "semantic",
    "confidence": 0.85,
    "reasoning": "Brief explanation"
  },
  {
    "target_idx": 2,
    "link_type": "supporting",
    "confidence": 0.92,
    "reasoning": "Brief explanation"
  }
]
```
```

### Link generation sample 2
```json
{
  "status": "valid",
  "confidence": 0.95,
  "result": [
    {
      "target_idx": 1,
      "link_type": "semantic",
      "confidence": 0.85,
      "reasoning": "Brief explanation"
    }
  ]
}
```

### Memory note samples
```text
lex: scheduled reports v2 design
lex: scheduled reports v2 documentation
vec: scheduled reports v2 design pattern implementation
vec: scheduled reports v2 documentation examples
hyde: Here are some code examples for scheduled reports v2. Each example demonstrates a common use case with working code.
```

```json
{
  "keywords": ["scheduled reports design", "kpi report scheduling", "admin scheduled reports"]
}
```

```json
{
  "keywords": ["scheduled reports design"]
  "tags": ["tag1", "tag2"]
  "context": "Brief summary"
}
```

## Why this patch
Current code assumed the model always returned perfect JSON. In practice, the remote llama-server path can return:
- valid JSON wrapped in fence junk
- partial JSON objects
- expansion-format `lex:/vec:/hyde:` text instead of the requested memory-note schema
- JSON-like objects missing commas between top-level fields
- object-wrapped link-generation results where the actual array lives under `result`

These are salvageable outputs that should not null out enrichment.

## Tests
Added/updated unit coverage in `tests/unit/amem.test.ts` for:
- partial JSON missing `tags` / `context`
- `lex:/vec:/hyde:` fallback output
- missing commas between top-level object fields
- object-wrapped link-generation arrays
- existing extractor behavior for plain JSON / fenced JSON / truncated JSON remains covered

## Verification
- `bun test tests/unit/amem.test.ts`
- repeated enrich smoke on real corpus with local 8088/8089/8090
- after parser hardening plus wrapper unwrap, sampled windows showed:
  - `note_invalid=0`
  - `link_invalid=0`
  - continued successful link creation and memory evolution

## Caveat
This patch hardens observed failure classes and materially improves real-corpus enrich behavior. It does not claim every possible malformed model output is fixed. Additional prompt tightening or structured remote response enforcement could still help later.
