### PR TITLE
feat(llm): support remote model overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ If your GPU lives on a separate machine, point the env vars at it:
 ```bash
 export CLAWMEM_EMBED_URL=http://gpu-host:8088
 export CLAWMEM_LLM_URL=http://gpu-host:8089
+export CLAWMEM_LLM_MODEL=qwen3
 export CLAWMEM_RERANK_URL=http://gpu-host:8090
 ```
 
@@ -944,6 +945,9 @@ Notes referenced by the agent during a session get boosted (`access_count++`). U
 | `CLAWMEM_EMBED_TPM_LIMIT` | `100000` | Tokens-per-minute limit for cloud embedding pacing. Match to your provider tier. |
 | `CLAWMEM_EMBED_DIMENSIONS` | (none) | Output dimensions for OpenAI `text-embedding-3-*` Matryoshka models (e.g. `512`, `1024`). |
 | `CLAWMEM_LLM_URL` | `http://localhost:8089` | LLM server URL for intent/query/A-MEM. Without it, falls to `node-llama-cpp` (if allowed). |
+| `CLAWMEM_LLM_MODEL` | `qwen3` | Model name sent to the configured LLM endpoint. Override this for OpenAI-compatible proxies such as `gpt-5.4-mini`. |
+| `CLAWMEM_LLM_REASONING_EFFORT` | (none) | Optional top-level `reasoning_effort` field for Chat Completions endpoints that support it (for example OpenAI reasoning models). Leave unset for llama-server/vLLM unless your serving stack explicitly accepts that field. |
+| `CLAWMEM_LLM_NO_THINK` | `true` | Append `/no_think` to remote LLM prompts. Set to `false` for standard OpenAI models and other endpoints that reject or treat the Qwen-style suffix as literal prompt text. |
 | `CLAWMEM_RERANK_URL` | `http://localhost:8090` | Reranker server URL. Without it, falls to `node-llama-cpp` (if allowed). |
 | `CLAWMEM_NO_LOCAL_MODELS` | `false` | Block `node-llama-cpp` from auto-downloading GGUF models. Set `true` for remote-only setups where you want fail-fast on unreachable endpoints. |
 | `CLAWMEM_MERGE_SCORE_NORMAL` | `0.93` | **v0.7.1.** Phase 2 consolidation merge-safety threshold when candidate and existing anchors align. Merges above this normalized 3-gram cosine score are allowed. |

--- a/docs/guides/hermes-plugin.md
+++ b/docs/guides/hermes-plugin.md
@@ -65,6 +65,9 @@ Set in your Hermes profile's `.env` or shell environment:
 | `CLAWMEM_PROFILE` | `balanced` | Retrieval profile: `speed` (BM25 only), `balanced` (hybrid), `deep` (full pipeline) |
 | `CLAWMEM_EMBED_URL` | — | GPU embedding server URL (e.g., `http://localhost:8088`) |
 | `CLAWMEM_LLM_URL` | — | GPU LLM server URL (e.g., `http://localhost:8089`) |
+| `CLAWMEM_LLM_MODEL` | `qwen3` | Model name sent to the GPU/cloud LLM endpoint (e.g., `qwen3`, `gpt-5.4-mini`) |
+| `CLAWMEM_LLM_REASONING_EFFORT` | — | Optional top-level `reasoning_effort` field for Chat Completions endpoints that support it (for example OpenAI reasoning models). Leave unset for llama-server/vLLM unless explicitly supported. |
+| `CLAWMEM_LLM_NO_THINK` | `true` | Append `/no_think` to remote prompts; set to `false` for standard OpenAI models and other endpoints that reject or treat the Qwen-style suffix as literal prompt text |
 | `CLAWMEM_RERANK_URL` | — | GPU reranker server URL (e.g., `http://localhost:8090`) |
 | `CLAWMEM_API_TOKEN` | — | Bearer token for REST API auth (optional, must match `clawmem serve` config) |
 

--- a/docs/guides/openclaw-plugin.md
+++ b/docs/guides/openclaw-plugin.md
@@ -112,6 +112,20 @@ The plugin manifest (`src/openclaw/openclaw.plugin.json`) supports:
 | `profile` | `balanced` | Performance profile |
 | `enableTools` | true | Register agent tools |
 | `servePort` | 7438 | REST API port for agent tools |
+| `gpuEmbed` | `http://localhost:8088` | Embedding endpoint override |
+| `gpuLlm` | `http://localhost:8089` | LLM endpoint override |
+| `gpuLlmModel` | `qwen3` | Model name sent to the configured LLM endpoint |
+| `gpuLlmReasoningEffort` | `(unset)` | Optional top-level `reasoning_effort` field for Chat Completions endpoints that support it (for example OpenAI reasoning models); unset omits the field |
+| `gpuLlmNoThink` | `true` | Append `/no_think` to remote LLM prompts. Set false for standard OpenAI models and other endpoints that reject or treat the suffix as literal prompt text |
+| `gpuRerank` | `http://localhost:8090` | Reranker endpoint override |
+
+For example, to use an OpenAI-compatible proxy instead of the default llama-server model selection:
+
+```bash
+openclaw config set plugins.entries.clawmem.config.gpuLlm http://127.0.0.1:8000
+openclaw config set plugins.entries.clawmem.config.gpuLlmModel gpt-5.4-mini
+openclaw config set plugins.entries.clawmem.config.gpuLlmNoThink false
+```
 
 ## Coexistence with OpenClaw Active Memory
 

--- a/docs/guides/setup-mcp.md
+++ b/docs/guides/setup-mcp.md
@@ -71,5 +71,6 @@ The `bin/clawmem` wrapper sets all GPU endpoint defaults. If running the MCP ser
 ```bash
 CLAWMEM_EMBED_URL=http://localhost:8088
 CLAWMEM_LLM_URL=http://localhost:8089
+CLAWMEM_LLM_MODEL=qwen3
 CLAWMEM_RERANK_URL=http://localhost:8090
 ```

--- a/docs/guides/systemd-services.md
+++ b/docs/guides/systemd-services.md
@@ -208,6 +208,7 @@ If GPU services run on a different machine, add environment overrides to both se
 [Service]
 Environment=CLAWMEM_EMBED_URL=http://gpu-host:8088
 Environment=CLAWMEM_LLM_URL=http://gpu-host:8089
+Environment=CLAWMEM_LLM_MODEL=qwen3
 Environment=CLAWMEM_RERANK_URL=http://gpu-host:8090
 ```
 
@@ -219,6 +220,7 @@ cat > ~/.config/systemd/user/clawmem-watcher.service.d/gpu.conf << 'EOF'
 [Service]
 Environment=CLAWMEM_EMBED_URL=http://gpu-host:8088
 Environment=CLAWMEM_LLM_URL=http://gpu-host:8089
+Environment=CLAWMEM_LLM_MODEL=qwen3
 Environment=CLAWMEM_RERANK_URL=http://gpu-host:8090
 EOF
 systemctl --user daemon-reload

--- a/docs/internals/entity-resolution.md
+++ b/docs/internals/entity-resolution.md
@@ -106,7 +106,9 @@ Point `CLAWMEM_LLM_URL` at a more capable model for all LLM tasks (query expansi
 
 ```bash
 # Example: use a 7B+ model instead of QMD 1.7B
-CLAWMEM_LLM_URL=http://localhost:8091 clawmem reindex --enrich
+CLAWMEM_LLM_URL=http://localhost:8091 \
+CLAWMEM_LLM_MODEL=your-7b-model \
+clawmem reindex --enrich
 ```
 
 Trade-off: query expansion is already well-served by QMD — a larger model is slower for the same task with marginal gains. Entity extraction benefits more.
@@ -117,7 +119,9 @@ Point the LLM at a cloud endpoint for higher-quality extraction. Any OpenAI-comp
 
 ```bash
 # Example: use an OpenAI-compatible API
-CLAWMEM_LLM_URL=https://api.example.com/v1 clawmem reindex --enrich
+CLAWMEM_LLM_URL=https://api.example.com/v1 \
+CLAWMEM_LLM_MODEL=gpt-5.4-mini \
+clawmem reindex --enrich
 ```
 
 Trade-off: cloud API calls have per-token costs. With 261 documents at ~2000 tokens each, a full re-enrichment is roughly 500K input tokens.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -151,6 +151,9 @@ The session ID is resolved from `--session-id <id>`, then `CLAUDE_SESSION_ID`, t
 | `CLAWMEM_EMBED_TPM_LIMIT` | `100000` | Tokens-per-minute limit for cloud embedding pacing |
 | `CLAWMEM_EMBED_DIMENSIONS` | — | Output dimensions for OpenAI `text-embedding-3-*` models |
 | `CLAWMEM_LLM_URL` | `http://localhost:8089` | LLM server |
+| `CLAWMEM_LLM_MODEL` | `qwen3` | Model name sent to the configured LLM endpoint |
+| `CLAWMEM_LLM_REASONING_EFFORT` | — | Optional top-level `reasoning_effort` field for Chat Completions endpoints that support it (for example OpenAI reasoning models). Leave unset for llama-server/vLLM unless explicitly supported. |
+| `CLAWMEM_LLM_NO_THINK` | `true` | Append `/no_think` to remote prompts; set `false` for standard OpenAI models and other endpoints that reject or treat it as literal prompt text |
 | `CLAWMEM_RERANK_URL` | `http://localhost:8090` | Reranker server |
 | `CLAWMEM_NO_LOCAL_MODELS` | `false` | Block node-llama-cpp auto-downloads |
 | `CLAWMEM_PROFILE` | `balanced` | Performance profile: `speed` (BM25 only), `balanced` (BM25+vector), `deep` (BM25+vector+expansion+reranking) |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -195,6 +195,7 @@ For remote GPU setups, add environment overrides (same pattern as the [watcher s
 ```ini
 Environment=CLAWMEM_EMBED_URL=http://gpu-host:8088
 Environment=CLAWMEM_LLM_URL=http://gpu-host:8089
+Environment=CLAWMEM_LLM_MODEL=qwen3
 Environment=CLAWMEM_RERANK_URL=http://gpu-host:8090
 ```
 

--- a/src/clawmem.ts
+++ b/src/clawmem.ts
@@ -1491,6 +1491,7 @@ async function cmdSetupOpenClaw(args: string[]) {
   console.log(`  3. Configure GPU endpoints (if not using defaults):`);
   console.log(`     ${c.cyan}openclaw config set plugins.entries.clawmem.config.gpuEmbed http://YOUR_GPU:8088${c.reset}`);
   console.log(`     ${c.cyan}openclaw config set plugins.entries.clawmem.config.gpuLlm http://YOUR_GPU:8089${c.reset}`);
+  console.log(`     ${c.cyan}openclaw config set plugins.entries.clawmem.config.gpuLlmModel qwen3${c.reset}`);
   console.log(`     ${c.cyan}openclaw config set plugins.entries.clawmem.config.gpuRerank http://YOUR_GPU:8090${c.reset}`);
   console.log();
   console.log(`  4. Start the REST API (for agent tools):`);

--- a/src/hermes/__init__.py
+++ b/src/hermes/__init__.py
@@ -15,6 +15,9 @@ Config via environment variables:
   CLAWMEM_PROFILE       — Retrieval profile: speed, balanced, deep (default: balanced)
   CLAWMEM_EMBED_URL     — GPU embedding server URL (optional)
   CLAWMEM_LLM_URL       — GPU LLM server URL (optional)
+  CLAWMEM_LLM_MODEL     — Model name sent to the GPU/cloud LLM endpoint (optional)
+  CLAWMEM_LLM_REASONING_EFFORT — Top-level reasoning_effort for supporting Chat Completions endpoints (optional)
+  CLAWMEM_LLM_NO_THINK  — Append /no_think to remote prompts; false disables it for standard OpenAI models (optional)
   CLAWMEM_RERANK_URL    — GPU reranker server URL (optional)
 
 Agent-context isolation:
@@ -295,6 +298,24 @@ class ClawMemProvider(MemoryProvider):
                 "secret": False,
                 "env_var": "CLAWMEM_LLM_URL",
             },
+            {
+                "key": "llm_model",
+                "description": "Model name sent to the GPU LLM server (e.g., qwen3, gpt-5.4-mini)",
+                "secret": False,
+                "env_var": "CLAWMEM_LLM_MODEL",
+            },
+            {
+                "key": "llm_reasoning_effort",
+                "description": "Optional top-level reasoning_effort for Chat Completions endpoints that support it",
+                "secret": False,
+                "env_var": "CLAWMEM_LLM_REASONING_EFFORT",
+            },
+            {
+                "key": "llm_no_think",
+                "description": "Append /no_think to remote LLM prompts; disable for standard OpenAI models",
+                "secret": False,
+                "env_var": "CLAWMEM_LLM_NO_THINK",
+            },
         ]
 
     # -- Core lifecycle --------------------------------------------------------
@@ -324,7 +345,15 @@ class ClawMemProvider(MemoryProvider):
             )
 
         # Build env for hook shell-outs (GPU endpoints, profile)
-        for var in ("CLAWMEM_EMBED_URL", "CLAWMEM_LLM_URL", "CLAWMEM_RERANK_URL", "CLAWMEM_PROFILE"):
+        for var in (
+            "CLAWMEM_EMBED_URL",
+            "CLAWMEM_LLM_URL",
+            "CLAWMEM_LLM_MODEL",
+            "CLAWMEM_LLM_REASONING_EFFORT",
+            "CLAWMEM_LLM_NO_THINK",
+            "CLAWMEM_RERANK_URL",
+            "CLAWMEM_PROFILE",
+        ):
             val = os.environ.get(var)
             if val:
                 self._env_extra[var] = val

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -238,6 +238,23 @@ export type LlamaCppConfig = {
    */
   remoteLlmUrl?: string;
   /**
+   * Remote LLM model name to send with chat completion requests.
+   * Env: CLAWMEM_LLM_MODEL
+   */
+  remoteLlmModel?: string;
+  /**
+   * Optional top-level reasoning_effort field for Chat Completions endpoints that support it.
+   * Example values: none, minimal, low, medium, high, xhigh.
+   * Env: CLAWMEM_LLM_REASONING_EFFORT
+   */
+  remoteLlmReasoningEffort?: string;
+  /**
+   * Whether to append /no_think to remote LLM prompts.
+   * Defaults to true to preserve current behavior with Qwen3-compatible endpoints.
+   * Env: CLAWMEM_LLM_NO_THINK
+   */
+  remoteLlmNoThink?: boolean;
+  /**
    * Inactivity timeout in ms before unloading contexts (default: 2 minutes, 0 to disable).
    *
    * Per node-llama-cpp lifecycle guidance, we prefer keeping models loaded and only disposing
@@ -259,6 +276,23 @@ export type LlamaCppConfig = {
  */
 // Default inactivity timeout: 2 minutes
 const DEFAULT_INACTIVITY_TIMEOUT_MS = 2 * 60 * 1000;
+const ALLOWED_REMOTE_LLM_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+
+function normalizeRemoteLlmReasoningEffort(value?: string): string | null {
+  const raw = (value || "").trim().toLowerCase();
+  if (!raw) return null;
+  if (!ALLOWED_REMOTE_LLM_REASONING_EFFORTS.has(raw)) {
+    console.warn(`[clawmem] Ignoring unsupported remoteLlmReasoningEffort=${raw}`);
+    return null;
+  }
+  return raw;
+}
+
+function buildRemoteChatCompletionsUrl(remoteLlmUrl: string): string {
+  const baseUrl = remoteLlmUrl.replace(/\/+$/, "");
+  const endpoint = baseUrl.endsWith("/v1") ? "/chat/completions" : "/v1/chat/completions";
+  return `${baseUrl}${endpoint}`;
+}
 
 export class LlamaCpp implements LLM {
   private llama: Llama | null = null;
@@ -276,6 +310,9 @@ export class LlamaCpp implements LLM {
   private remoteEmbedApiKey: string | null;
   private remoteEmbedModel: string;
   private remoteLlmUrl: string | null;
+  private remoteLlmModel: string;
+  private remoteLlmReasoningEffort: string | null;
+  private remoteLlmNoThink: boolean;
 
   // Ensure we don't load the same model concurrently (which can allocate duplicate VRAM).
   private embedModelLoadPromise: Promise<LlamaModel> | null = null;
@@ -306,6 +343,10 @@ export class LlamaCpp implements LLM {
     this.remoteEmbedApiKey = config.remoteEmbedApiKey || null;
     this.remoteEmbedModel = config.remoteEmbedModel || "embedding";
     this.remoteLlmUrl = config.remoteLlmUrl || null;
+    const normalizedRemoteLlmModel = config.remoteLlmModel?.trim();
+    this.remoteLlmModel = normalizedRemoteLlmModel || "qwen3";
+    this.remoteLlmReasoningEffort = normalizeRemoteLlmReasoningEffort(config.remoteLlmReasoningEffort);
+    this.remoteLlmNoThink = config.remoteLlmNoThink ?? true;
     this.inactivityTimeoutMs = config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
     this.disposeModelsOnInactivity = config.disposeModelsOnInactivity ?? false;
   }
@@ -921,15 +962,19 @@ export class LlamaCpp implements LLM {
     // Re-check: concurrent call may have set cooldown while we were awaited
     if (this.isRemoteLlmDown()) return null;
     try {
-      const resp = await fetch(`${this.remoteLlmUrl}/v1/chat/completions`, {
+      const body: Record<string, unknown> = {
+        model: this.remoteLlmModel,
+        messages: [{ role: "user", content: this.remoteLlmNoThink ? `${prompt} /no_think` : prompt }],
+        max_tokens: maxTokens,
+        temperature,
+      };
+      if (this.remoteLlmReasoningEffort) {
+        body.reasoning_effort = this.remoteLlmReasoningEffort;
+      }
+      const resp = await fetch(buildRemoteChatCompletionsUrl(this.remoteLlmUrl!), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: "qwen3",
-          messages: [{ role: "user", content: `${prompt} /no_think` }],
-          max_tokens: maxTokens,
-          temperature,
-        }),
+        body: JSON.stringify(body),
         signal,
       });
 
@@ -1254,6 +1299,13 @@ export function getDefaultLlamaCpp(): LlamaCpp {
       remoteEmbedApiKey: embedApiKey,
       remoteEmbedModel: process.env.CLAWMEM_EMBED_MODEL || undefined,
       remoteLlmUrl: process.env.CLAWMEM_LLM_URL || undefined,
+      remoteLlmModel: process.env.CLAWMEM_LLM_MODEL?.trim() || undefined,
+      remoteLlmReasoningEffort: process.env.CLAWMEM_LLM_REASONING_EFFORT || undefined,
+      remoteLlmNoThink: (() => {
+        const raw = (process.env.CLAWMEM_LLM_NO_THINK || "").trim().toLowerCase();
+        if (!raw) return undefined;
+        return !["0", "false", "no", "off"].includes(raw);
+      })(),
     });
   }
   return defaultLlamaCpp;
@@ -1276,4 +1328,3 @@ export async function disposeDefaultLlamaCpp(): Promise<void> {
     defaultLlamaCpp = null;
   }
 }
-

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -107,6 +107,13 @@ const clawmemPlugin = {
       env: {
         ...(pluginCfg.gpuEmbed ? { CLAWMEM_EMBED_URL: pluginCfg.gpuEmbed as string } : {}),
         ...(pluginCfg.gpuLlm ? { CLAWMEM_LLM_URL: pluginCfg.gpuLlm as string } : {}),
+        ...(pluginCfg.gpuLlmModel ? { CLAWMEM_LLM_MODEL: pluginCfg.gpuLlmModel as string } : {}),
+        ...(pluginCfg.gpuLlmReasoningEffort
+          ? { CLAWMEM_LLM_REASONING_EFFORT: pluginCfg.gpuLlmReasoningEffort as string }
+          : {}),
+        ...(pluginCfg.gpuLlmNoThink !== undefined
+          ? { CLAWMEM_LLM_NO_THINK: String(pluginCfg.gpuLlmNoThink) }
+          : {}),
         ...(pluginCfg.gpuRerank ? { CLAWMEM_RERANK_URL: pluginCfg.gpuRerank as string } : {}),
         CLAWMEM_PROFILE: profile,
       },

--- a/src/openclaw/openclaw.plugin.json
+++ b/src/openclaw/openclaw.plugin.json
@@ -41,6 +41,23 @@
       "help": "URL for ClawMem LLM (query expansion, extraction)",
       "advanced": true
     },
+    "gpuLlmModel": {
+      "label": "LLM Model",
+      "placeholder": "qwen3",
+      "help": "Model name sent to the configured LLM endpoint",
+      "advanced": true
+    },
+    "gpuLlmReasoningEffort": {
+      "label": "Reasoning Effort",
+      "placeholder": "(unset)",
+      "help": "Optional top-level reasoning_effort for Chat Completions endpoints that support it. Unset omits the field.",
+      "advanced": true
+    },
+    "gpuLlmNoThink": {
+      "label": "Append /no_think",
+      "help": "Append /no_think to remote LLM prompts (default: true). Disable for standard OpenAI models.",
+      "advanced": true
+    },
     "gpuRerank": {
       "label": "Reranker Endpoint",
       "placeholder": "http://localhost:8090",
@@ -77,6 +94,16 @@
       },
       "gpuLlm": {
         "type": "string"
+      },
+      "gpuLlmModel": {
+        "type": "string"
+      },
+      "gpuLlmReasoningEffort": {
+        "type": "string",
+        "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
+      },
+      "gpuLlmNoThink": {
+        "type": "boolean"
       },
       "gpuRerank": {
         "type": "string"

--- a/tests/unit/hermes-plugin.test.ts
+++ b/tests/unit/hermes-plugin.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Hermes plugin env surface", () => {
+  test("documents and forwards remote LLM env vars", async () => {
+    const file = Bun.file(`${import.meta.dir}/../../src/hermes/__init__.py`);
+    const content = await file.text();
+
+    expect(content).toContain("CLAWMEM_LLM_MODEL");
+    expect(content).toContain("CLAWMEM_LLM_REASONING_EFFORT");
+    expect(content).toContain("CLAWMEM_LLM_NO_THINK");
+    expect(content).toContain('"env_var": "CLAWMEM_LLM_MODEL"');
+    expect(content).toContain('"env_var": "CLAWMEM_LLM_REASONING_EFFORT"');
+    expect(content).toContain('"env_var": "CLAWMEM_LLM_NO_THINK"');
+  });
+});

--- a/tests/unit/llm-remote-config.test.ts
+++ b/tests/unit/llm-remote-config.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+  disposeDefaultLlamaCpp,
+  getDefaultLlamaCpp,
+  LlamaCpp,
+  setDefaultLlamaCpp,
+} from "../../src/llm.ts";
+
+const originalFetch = globalThis.fetch;
+
+describe("remote LLM model selection", () => {
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.CLAWMEM_LLM_URL;
+    delete process.env.CLAWMEM_LLM_MODEL;
+    delete process.env.CLAWMEM_LLM_NO_THINK;
+    delete process.env.CLAWMEM_LLM_REASONING_EFFORT;
+    await disposeDefaultLlamaCpp();
+    setDefaultLlamaCpp(null);
+  });
+
+  it("defaults remote chat completions to qwen3 when no model override is set", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = new LlamaCpp({ remoteLlmUrl: "http://localhost:8089" });
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("qwen3");
+    expect((seenBody?.messages as { content: string }[])[0]?.content).toContain("/no_think");
+  });
+
+  it("uses remoteLlmModel when the override is configured on the instance", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = new LlamaCpp({
+      remoteLlmUrl: "http://localhost:8089",
+      remoteLlmModel: "gpt-5.4-mini",
+    });
+
+    const result = await llm.generate("test prompt");
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+    expect(result?.model).toBe("gpt-5.4-mini");
+  });
+
+  it("normalizes remoteLlmUrl when it already includes a /v1 suffix", async () => {
+    let seenUrl: string | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      seenUrl = String(url);
+      const seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = new LlamaCpp({
+      remoteLlmUrl: "https://api.example.com/v1/",
+      remoteLlmModel: "gpt-5.4-mini",
+    });
+
+    await llm.generate("test prompt");
+
+    expect(seenUrl).toBe("https://api.example.com/v1/chat/completions");
+  });
+
+  it("uses CLAWMEM_LLM_MODEL when bootstrapping the default LLM instance from env", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    process.env.CLAWMEM_LLM_URL = "http://localhost:8089";
+    process.env.CLAWMEM_LLM_MODEL = "gpt-5.4-mini";
+
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = getDefaultLlamaCpp();
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+  });
+
+  it("trims CLAWMEM_LLM_MODEL when bootstrapping the default LLM instance from env", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    process.env.CLAWMEM_LLM_URL = "http://localhost:8089";
+    process.env.CLAWMEM_LLM_MODEL = "  gpt-5.4-mini  ";
+
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = getDefaultLlamaCpp();
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+  });
+
+  it("trims remoteLlmModel when the override is configured on the instance", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = new LlamaCpp({
+      remoteLlmUrl: "http://localhost:8089",
+      remoteLlmModel: "  gpt-5.4-mini  ",
+    });
+
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+  });
+
+  it("omits /no_think when CLAWMEM_LLM_NO_THINK disables it", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    process.env.CLAWMEM_LLM_URL = "http://localhost:8089";
+    process.env.CLAWMEM_LLM_MODEL = "gpt-5.4-mini";
+    process.env.CLAWMEM_LLM_NO_THINK = "false";
+
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = getDefaultLlamaCpp();
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+    expect((seenBody?.messages as { content: string }[])[0]?.content).toBe("test prompt");
+  });
+
+  it("sends top-level reasoning_effort only when CLAWMEM_LLM_REASONING_EFFORT is configured", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    process.env.CLAWMEM_LLM_URL = "http://localhost:8089";
+    process.env.CLAWMEM_LLM_MODEL = "gpt-5.4-mini";
+    process.env.CLAWMEM_LLM_REASONING_EFFORT = "minimal";
+
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = getDefaultLlamaCpp();
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+    expect(seenBody?.reasoning_effort).toBe("minimal");
+    expect(seenBody?.reasoning).toBeUndefined();
+  });
+
+  it("accepts 'none' as a reasoning effort override", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    process.env.CLAWMEM_LLM_URL = "http://localhost:8089";
+    process.env.CLAWMEM_LLM_MODEL = "gpt-5.4-mini";
+    process.env.CLAWMEM_LLM_REASONING_EFFORT = "none";
+
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = getDefaultLlamaCpp();
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+    expect(seenBody?.reasoning_effort).toBe("none");
+  });
+
+  it("accepts 'xhigh' as a reasoning effort override", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    process.env.CLAWMEM_LLM_URL = "http://localhost:8089";
+    process.env.CLAWMEM_LLM_MODEL = "gpt-5.4-mini";
+    process.env.CLAWMEM_LLM_REASONING_EFFORT = "xhigh";
+
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = getDefaultLlamaCpp();
+    await llm.generate("test prompt");
+
+    expect(seenBody?.model).toBe("gpt-5.4-mini");
+    expect(seenBody?.reasoning_effort).toBe("xhigh");
+  });
+
+  it("normalizes and validates instance-level remoteLlmReasoningEffort overrides", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = new LlamaCpp({
+      remoteLlmUrl: "http://localhost:8089",
+      remoteLlmModel: "gpt-5.4-mini",
+      remoteLlmReasoningEffort: "  HIGH  ",
+    });
+    await llm.generate("test prompt");
+    expect(seenBody?.reasoning_effort).toBe("high");
+
+    seenBody = undefined;
+    const nextLlm = new LlamaCpp({
+      remoteLlmUrl: "http://localhost:8089",
+      remoteLlmModel: "gpt-5.4-mini",
+      remoteLlmReasoningEffort: "unsupported-tier",
+    });
+    await nextLlm.generate("test prompt");
+    expect(seenBody?.reasoning_effort).toBeUndefined();
+  });
+
+  it("normalizes and validates CLAWMEM_LLM_REASONING_EFFORT before sending it", async () => {
+    let seenBody: Record<string, unknown> | undefined;
+    process.env.CLAWMEM_LLM_URL = "http://localhost:8089";
+    process.env.CLAWMEM_LLM_MODEL = "gpt-5.4-mini";
+    process.env.CLAWMEM_LLM_REASONING_EFFORT = "  LOW  ";
+
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        model: seenBody.model,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const llm = getDefaultLlamaCpp();
+    await llm.generate("test prompt");
+    expect(seenBody?.reasoning_effort).toBe("low");
+
+    seenBody = undefined;
+    process.env.CLAWMEM_LLM_REASONING_EFFORT = "unsupported-tier";
+    await disposeDefaultLlamaCpp();
+    setDefaultLlamaCpp(null);
+
+    const nextLlm = getDefaultLlamaCpp();
+    await nextLlm.generate("test prompt");
+    expect(seenBody?.reasoning_effort).toBeUndefined();
+  });
+});

--- a/tests/unit/openclaw-plugin.test.ts
+++ b/tests/unit/openclaw-plugin.test.ts
@@ -144,6 +144,43 @@ describe("plugin manifest (§14.3 kind=memory)", () => {
     expect(content.configSchema.properties.tokenBudget).toBeDefined();
     expect(content.configSchema.properties.profile).toBeDefined();
   });
+
+  test("openclaw.plugin.json exposes remote LLM config in uiHints and configSchema", async () => {
+    const file = Bun.file(`${import.meta.dir}/../../src/openclaw/openclaw.plugin.json`);
+    const content = await file.json();
+    expect(content.uiHints.gpuLlmModel).toBeDefined();
+    expect(content.uiHints.gpuLlmReasoningEffort).toBeDefined();
+    expect(content.uiHints.gpuLlmNoThink).toBeDefined();
+    expect(content.configSchema.properties.gpuLlmModel).toBeDefined();
+    expect(content.configSchema.properties.gpuLlmReasoningEffort).toBeDefined();
+    expect(content.configSchema.properties.gpuLlmNoThink).toBeDefined();
+    expect(content.configSchema.properties.gpuLlmReasoningEffort.enum).toEqual([
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  test("openclaw.plugin.json does not imply a default reasoning effort is sent", async () => {
+    const file = Bun.file(`${import.meta.dir}/../../src/openclaw/openclaw.plugin.json`);
+    const content = await file.json();
+    expect(content.uiHints.gpuLlmReasoningEffort.placeholder).toBe("(unset)");
+    expect(content.uiHints.gpuLlmReasoningEffort.help).toContain("Optional top-level reasoning_effort");
+  });
+
+  test("openclaw index maps remote LLM config to CLAWMEM env vars", async () => {
+    const file = Bun.file(`${import.meta.dir}/../../src/openclaw/index.ts`);
+    const content = await file.text();
+    expect(content).toContain("pluginCfg.gpuLlmModel");
+    expect(content).toContain("CLAWMEM_LLM_MODEL");
+    expect(content).toContain("pluginCfg.gpuLlmReasoningEffort");
+    expect(content).toContain("CLAWMEM_LLM_REASONING_EFFORT");
+    expect(content).toContain("pluginCfg.gpuLlmNoThink");
+    expect(content).toContain("CLAWMEM_LLM_NO_THINK");
+  });
 });
 
 // =============================================================================
@@ -936,6 +973,7 @@ describe("Shipping Condition 2 — setup-time migration text is present", () => 
     // pattern, which failed on v2026.4.11 because the slot validator rejected
     // unregistered plugin ids.
     expect(content).toContain("openclaw plugins enable clawmem");
+    expect(content).toContain("plugins.entries.clawmem.config.gpuLlmModel");
     // Dreaming-disable note is also non-negotiable per §14.9
     expect(content).toContain("dreaming.enabled = false");
   });


### PR DESCRIPTION
## Summary
- add configurable remote LLM controls while preserving upstream defaults (`qwen3` on `http://localhost:8089`)
- support `CLAWMEM_LLM_MODEL`, `CLAWMEM_LLM_NO_THINK`, and `CLAWMEM_LLM_REASONING_EFFORT` for OpenAI-compatible remote endpoints
- use the standard top-level `reasoning_effort` field on `/v1/chat/completions`
- thread the settings through OpenClaw and Hermes, tighten validation/schema/docs, and add focused contract tests

## Verification
- `bun test`

## Notes
- branch was squashed to a single commit before opening upstream
- local-only `docs/plans/` remains untracked and is not part of this PR
