### PR TITLE
fix: harden pilot memory retrieval and fallback behavior

### DIFF
--- a/src/amem.ts
+++ b/src/amem.ts
@@ -588,6 +588,25 @@ export interface MemoryLink {
   reasoning: string;
 }
 
+function isVectorIndexUnavailable(error: unknown): boolean {
+  const message = String((error as any)?.message ?? error).toLowerCase();
+  return message.includes("no such table: vectors_vec") ||
+    message.includes("no such column: hash_seq") ||
+    message.includes("no such column: embedding") ||
+    message.includes("no such column: v1.embedding") ||
+    message.includes("no such column: v2.embedding") ||
+    message.includes("no such function: vec_distance_cosine") ||
+    message.includes("no such module: vec0");
+}
+
+function isSqlSchemaError(error: unknown): boolean {
+  const message = String((error as any)?.message ?? error).toLowerCase();
+  return message.includes("no such column:") ||
+    message.includes("no such table:") ||
+    message.includes("no such function:") ||
+    message.includes("no such module:");
+}
+
 /**
  * Generate typed memory links for a document based on semantic similarity.
  * Finds k-nearest neighbors and uses LLM to determine relationship types.
@@ -617,26 +636,49 @@ export async function generateMemoryLinks(
       return 0;
     }
 
+    // Indexing may run before vector tables/embeddings are ready.
+    // Degrade quietly here instead of surfacing misleading SQL errors.
+    const vecTableExists = !!store.db.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`
+    ).get();
+    if (!vecTableExists) return 0;
+
     // Find k-nearest neighbors using vector similarity
-    const neighbors = store.db.prepare(`
-      SELECT
-        d2.id as target_id,
-        d2.title as target_title,
-        d2.amem_context as target_context,
-        vec_distance_cosine(v1.embedding, v2.embedding) as distance
-      FROM vectors_vec v1, vectors_vec v2
-      JOIN documents d2 ON v2.hash_seq = d2.hash || '_0'
-      WHERE v1.hash_seq = ? || '_0'
-        AND d2.id != ?
-        AND d2.active = 1
-      ORDER BY distance
-      LIMIT ?
-    `).all(sourceDoc.hash, sourceDoc.id, kNeighbors) as {
+    let neighbors: {
       target_id: number;
       target_title: string;
       target_context: string | null;
       distance: number;
-    }[];
+    }[] = [];
+    try {
+      const sourceVectorExists = !!store.db.prepare(
+        `SELECT 1 FROM vectors_vec WHERE hash_seq = ? LIMIT 1`
+      ).get(`${sourceDoc.hash}_0`);
+      if (!sourceVectorExists) return 0;
+
+      neighbors = store.db.prepare(`
+        SELECT
+          d2.id as target_id,
+          d2.title as target_title,
+          d2.amem_context as target_context,
+          vec_distance_cosine(v1.embedding, v2.embedding) as distance
+        FROM vectors_vec v1, vectors_vec v2
+        JOIN documents d2 ON v2.hash_seq = d2.hash || '_0'
+        WHERE v1.hash_seq = ? || '_0'
+          AND d2.id != ?
+          AND d2.active = 1
+        ORDER BY distance
+        LIMIT ?
+      `).all(sourceDoc.hash, sourceDoc.id, kNeighbors) as {
+        target_id: number;
+        target_title: string;
+        target_context: string | null;
+        distance: number;
+      }[];
+    } catch (error) {
+      if (isVectorIndexUnavailable(error)) return 0;
+      throw error;
+    }
 
     if (neighbors.length === 0) {
       console.log(`[amem] No neighbors found for docId ${docId}`);
@@ -737,6 +779,9 @@ Include all ${neighbors.length} neighbors in your response.`;
     console.log(`[amem] Created ${linksCreated} links for docId ${docId}`);
     return linksCreated;
   } catch (err) {
+    if (isSqlSchemaError(err) && !isVectorIndexUnavailable(err)) {
+      throw err;
+    }
     console.log(`[amem] Error generating memory links for docId ${docId}:`, err);
     return 0;
   }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -332,6 +332,8 @@ export class LlamaCpp implements LLM {
   // Resets after cooldown expires — one network hiccup doesn't permanently disable GPU.
   private remoteEmbedDownUntil = 0;
   private remoteLlmDownUntil = 0;
+  private remoteEmbedFallbackNotifiedUntil = 0;
+  private remoteLlmFallbackNotifiedUntil = 0;
   private static readonly REMOTE_COOLDOWN_MS = 60_000; // 60s cooldown on transport failure
 
   constructor(config: LlamaCppConfig = {}) {
@@ -616,13 +618,21 @@ export class LlamaCpp implements LLM {
       if (result) return result;
       // Cloud providers don't fall back — if API key is set, the user chose cloud
       if (this.isCloudEmbedding()) return null;
+      // HTTP/API errors mean the endpoint is reachable; only transport
+      // failures set cooldown and fall through to local fallback.
+      if (!this.isRemoteEmbedDown()) return null;
       // Transport failure already set cooldown in embedRemote — fall through
     }
 
     // Remote is in cooldown or was never configured — try local fallback
     if (this.remoteEmbedUrl && this.isRemoteEmbedDown()) {
       if (process.env.CLAWMEM_NO_LOCAL_MODELS === "true") return null;
-      console.error("[embed] Remote embed in cooldown, using in-process fallback");
+      this.noteRemoteFallback(
+        "embed",
+        this.isLoopbackUrl(this.remoteEmbedUrl)
+          ? "[embed] Local embedding endpoint unavailable; using in-process fallback during cooldown"
+          : "[embed] Remote embed in cooldown, using in-process fallback"
+      );
     }
 
     // In-process fallback via node-llama-cpp (auto-downloads EmbeddingGemma on first use)
@@ -645,13 +655,21 @@ export class LlamaCpp implements LLM {
       if (results.some(r => r !== null)) return results;
       // Cloud providers don't fall back
       if (this.isCloudEmbedding()) return results;
+      // HTTP/API errors mean the endpoint is reachable; only transport
+      // failures set cooldown and fall through to local fallback.
+      if (!this.isRemoteEmbedDown()) return results;
       // Transport failure already set cooldown in embedRemoteBatch — fall through
     }
 
     // Remote is in cooldown or was never configured — try local fallback
     if (this.remoteEmbedUrl && this.isRemoteEmbedDown()) {
       if (process.env.CLAWMEM_NO_LOCAL_MODELS === "true") return texts.map(() => null);
-      console.error("[embed] Remote embed in cooldown, using in-process fallback");
+      this.noteRemoteFallback(
+        "embed",
+        this.isLoopbackUrl(this.remoteEmbedUrl)
+          ? "[embed] Local embedding endpoint unavailable; using in-process fallback during cooldown"
+          : "[embed] Remote embed in cooldown, using in-process fallback"
+      );
     }
 
     // In-process fallback via node-llama-cpp
@@ -717,7 +735,9 @@ export class LlamaCpp implements LLM {
         code === "UND_ERR_CONNECT_TIMEOUT") return true;
     const msg = String((error as any)?.message || "").toLowerCase();
     if (msg.includes("econnrefused") || msg.includes("etimedout") || msg.includes("enotfound") ||
-        msg.includes("ehostunreach") || msg.includes("enetunreach")) return true;
+        msg.includes("ehostunreach") || msg.includes("enetunreach") ||
+        msg.includes("unable to connect") || msg.includes("connectionrefused") ||
+        msg.includes("connection refused")) return true;
     return false;
   }
 
@@ -734,12 +754,53 @@ export class LlamaCpp implements LLM {
     return Date.now() < this.remoteEmbedDownUntil;
   }
 
+  private isLoopbackUrl(url: string | null | undefined): boolean {
+    if (!url) return false;
+    try {
+      const parsed = new URL(url);
+      return parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1";
+    } catch {
+      const lower = url.toLowerCase();
+      return lower.includes("localhost") || lower.includes("127.0.0.1") || lower.includes("[::1]");
+    }
+  }
+
+  private noteRemoteFallback(kind: "embed" | "llm", message: string): void {
+    const now = Date.now();
+    if (kind === "embed") {
+      if (now < this.remoteEmbedFallbackNotifiedUntil) return;
+      this.remoteEmbedFallbackNotifiedUntil = this.remoteEmbedDownUntil || (now + LlamaCpp.REMOTE_COOLDOWN_MS);
+      if (this.isLoopbackUrl(this.remoteEmbedUrl)) console.warn(message);
+      else console.error(message);
+      return;
+    }
+
+    if (now < this.remoteLlmFallbackNotifiedUntil) return;
+    this.remoteLlmFallbackNotifiedUntil = this.remoteLlmDownUntil || (now + LlamaCpp.REMOTE_COOLDOWN_MS);
+    if (this.isLoopbackUrl(this.remoteLlmUrl)) console.warn(message);
+    else console.error(message);
+  }
+
   private markRemoteLlmDown(): void {
     this.remoteLlmDownUntil = Date.now() + LlamaCpp.REMOTE_COOLDOWN_MS;
+    this.remoteLlmFallbackNotifiedUntil = 0;
+    this.noteRemoteFallback(
+      "llm",
+      this.isLoopbackUrl(this.remoteLlmUrl)
+        ? "[generate] Local LLM endpoint unavailable, cooldown 60s before retry"
+        : "[generate] Remote LLM unreachable, cooldown 60s before retry"
+    );
   }
 
   private markRemoteEmbedDown(): void {
     this.remoteEmbedDownUntil = Date.now() + LlamaCpp.REMOTE_COOLDOWN_MS;
+    this.remoteEmbedFallbackNotifiedUntil = 0;
+    this.noteRemoteFallback(
+      "embed",
+      this.isLoopbackUrl(this.remoteEmbedUrl)
+        ? "[embed] Local embedding endpoint unavailable, cooldown 60s before retry"
+        : "[embed] Remote embed server unreachable, cooldown 60s before retry"
+    );
   }
 
   // ---------- Remote embedding (GPU server or cloud API via /v1/embeddings) ----------
@@ -840,7 +901,6 @@ export class LlamaCpp implements LLM {
         };
       } catch (error) {
         if (this.isTransportError(error)) {
-          console.error("[embed] Remote embed server unreachable, cooldown 60s");
           this.markRemoteEmbedDown();
         } else {
           console.error("[embed] Remote embed error:", error);
@@ -892,7 +952,6 @@ export class LlamaCpp implements LLM {
         return results;
       } catch (error) {
         if (this.isTransportError(error)) {
-          console.error("[embed] Remote batch embed server unreachable, cooldown 60s");
           this.markRemoteEmbedDown();
         } else {
           console.error("[embed] Remote batch embed error:", error);
@@ -920,7 +979,12 @@ export class LlamaCpp implements LLM {
     // Remote is in cooldown or was never configured — try local fallback
     if (this.remoteLlmUrl && this.isRemoteLlmDown()) {
       if (process.env.CLAWMEM_NO_LOCAL_MODELS === "true") return null;
-      console.error("[generate] Remote LLM in cooldown, falling back to in-process generation");
+      this.noteRemoteFallback(
+        "llm",
+        this.isLoopbackUrl(this.remoteLlmUrl)
+          ? "[generate] Local LLM endpoint unavailable; using in-process generation during cooldown"
+          : "[generate] Remote LLM in cooldown, falling back to in-process generation"
+      );
     }
 
     // Local fallback via node-llama-cpp (CPU)
@@ -1000,7 +1064,6 @@ export class LlamaCpp implements LLM {
         return null;
       }
       if (this.isTransportError(error)) {
-        console.error("[generate] Remote LLM server unreachable, cooldown 60s");
         this.markRemoteLlmDown();
       } else {
         console.error("[generate] Remote LLM error:", error);
@@ -1089,7 +1152,12 @@ Output:`;
         if (includeLexical) fallback.unshift({ type: 'lex', text: query });
         return fallback;
       }
-      console.error("[expandQuery] Remote LLM in cooldown, falling back to in-process grammar expansion");
+      this.noteRemoteFallback(
+        "llm",
+        this.isLoopbackUrl(this.remoteLlmUrl)
+          ? "[expandQuery] Local LLM endpoint unavailable; using in-process grammar expansion during cooldown"
+          : "[expandQuery] Remote LLM in cooldown, falling back to in-process grammar expansion"
+      );
     }
 
     const llama = await this.ensureLlama();

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -254,6 +254,26 @@ export type ScoredResult = EnrichedResult & {
 
 export type CoActivationFn = (path: string) => { path: string; count: number }[];
 
+const STABLE_PROFILE_PATTERNS = [
+  /\b(pronouns?|timezone|time\s*zone|location|locale|home\s+base)\b/i,
+  /\b(preferences?|prefers?|identity|profile|bio|about\s+me)\b/i,
+  /\b(who\s+(am\s+i|is\s+\w+)|what\s+(do\s+i|does\s+\w+)\s+(prefer|use|avoid))\b/i,
+];
+
+function hasStableProfileIntent(query: string): boolean {
+  return STABLE_PROFILE_PATTERNS.some(p => p.test(query));
+}
+
+function canonicalMemoryMultiplier(path: string, contentType: string, query: string): number {
+  if (hasRecencyIntent(query) || !hasStableProfileIntent(query)) return 1.0;
+
+  const lower = path.toLowerCase();
+  if (/(^|\/)(core\/memory|memory\/core|profile|identity|soul)\.md$/.test(lower)) return 1.14;
+  if (/(^|\/)users\/[^/]+\.md$/.test(lower)) return 1.14;
+  if (contentType === "preference") return 1.08;
+  return 1.0;
+}
+
 export function applyCompositeScoring(
   results: EnrichedResult[],
   query: string,
@@ -290,6 +310,8 @@ export function applyCompositeScoring(
     const freqSignal = revisions * 2 + duplicates; // revisions weighted 2x
     const freqBoost = freqSignal > 0 ? Math.min(0.10, Math.log1p(freqSignal) * 0.03) : 0;
     adjusted *= (1 + freqBoost);
+
+    adjusted *= canonicalMemoryMultiplier(r.displayPath, r.contentType, query);
 
     // Pin boost: +0.3 additive, capped at 1.0
     if (r.pinned) {

--- a/tests/unit/amem.test.ts
+++ b/tests/unit/amem.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "bun:test";
 
-import { extractJsonFromLLM, generateMemoryLinks, parseLinkGenerationFromLLM, parseMemoryNoteFromLLM } from "../../src/amem.ts";
+import {
+  extractJsonFromLLM,
+  generateMemoryLinks,
+  parseLinkGenerationFromLLM,
+  parseMemoryNoteFromLLM,
+} from "../../src/amem.ts";
+import { insertContent, insertDocument } from "../../src/store.ts";
 import { createTestStore, seedDocuments } from "../helpers/test-store.ts";
 
 // ─── extractJsonFromLLM ─────────────────────────────────────────────
@@ -388,5 +394,78 @@ describe("generateMemoryLinks", () => {
     } finally {
       store.close();
     }
+  });
+});
+
+// ─── generateMemoryLinks vector readiness ───────────────────────────
+
+describe("generateMemoryLinks vector readiness", () => {
+  it("returns 0 when vectors_vec is not ready", async () => {
+    const store = createTestStore();
+    store.db.exec("DROP TABLE IF EXISTS vectors_vec");
+
+    const now = new Date().toISOString();
+    insertContent(store.db, "hash-a", "Profile facts", now);
+    insertDocument(store.db, "test", "users/cooper.md", "Cooper", "hash-a", now, now);
+    const row = store.db.prepare("SELECT id FROM documents WHERE hash = ?").get("hash-a") as { id: number };
+
+    const count = await generateMemoryLinks(store, {} as any, row.id);
+    expect(count).toBe(0);
+  });
+
+  it("returns 0 when the source document has no vector row yet", async () => {
+    const store = createTestStore();
+    store.db.exec("DROP TABLE IF EXISTS vectors_vec");
+    store.db.exec("CREATE TABLE vectors_vec (hash_seq TEXT PRIMARY KEY, embedding BLOB)");
+
+    const now = new Date().toISOString();
+    insertContent(store.db, "hash-a", "Profile facts", now);
+    insertDocument(store.db, "test", "users/cooper.md", "Cooper", "hash-a", now, now);
+    const row = store.db.prepare("SELECT id FROM documents WHERE hash = ?").get("hash-a") as { id: number };
+
+    const count = await generateMemoryLinks(store, {} as any, row.id);
+    expect(count).toBe(0);
+  });
+
+  it("returns 0 when the vector neighbor query throws for vector columns", async () => {
+    const store = createTestStore();
+    store.db.exec("DROP TABLE IF EXISTS vectors_vec");
+    store.db.exec("CREATE TABLE vectors_vec (hash_seq TEXT PRIMARY KEY)");
+
+    const now = new Date().toISOString();
+    insertContent(store.db, "hash-a", "Profile facts", now);
+    insertContent(store.db, "hash-b", "More profile facts", now);
+    insertDocument(store.db, "test", "users/cooper.md", "Cooper", "hash-a", now, now);
+    insertDocument(store.db, "test", "notes/peer.md", "Peer", "hash-b", now, now);
+    store.db.prepare("INSERT INTO vectors_vec (hash_seq) VALUES (?)").run("hash-a_0");
+    store.db.prepare("INSERT INTO vectors_vec (hash_seq) VALUES (?)").run("hash-b_0");
+    const row = store.db.prepare("SELECT id FROM documents WHERE hash = ?").get("hash-a") as { id: number };
+
+    const count = await generateMemoryLinks(store, {} as any, row.id);
+    expect(count).toBe(0);
+  });
+
+  it("rethrows non-vector SQL errors from the neighbor query", async () => {
+    const store = createTestStore();
+    store.db.exec("DROP TABLE IF EXISTS vectors_vec");
+    store.db.exec("CREATE TABLE vectors_vec (hash_seq TEXT PRIMARY KEY, embedding BLOB)");
+
+    const now = new Date().toISOString();
+    insertContent(store.db, "hash-a", "Profile facts", now);
+    insertDocument(store.db, "test", "users/cooper.md", "Cooper", "hash-a", now, now);
+    store.db.prepare("INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)").run("hash-a_0", new Uint8Array([1, 2, 3]));
+    const row = store.db.prepare("SELECT id FROM documents WHERE hash = ?").get("hash-a") as { id: number };
+
+    const originalPrepare = store.db.prepare.bind(store.db);
+    (store.db as any).prepare = (sql: string) => {
+      if (sql.includes("vec_distance_cosine")) {
+        throw new Error("no such column: d2.active");
+      }
+      return originalPrepare(sql);
+    };
+
+    await expect(generateMemoryLinks(store, {} as any, row.id)).rejects.toThrow(
+      "no such column: d2.active"
+    );
   });
 });

--- a/tests/unit/llm-fallback.test.ts
+++ b/tests/unit/llm-fallback.test.ts
@@ -108,6 +108,42 @@ describe("LLM Remote Fallback", () => {
       expect(fetchCalled).toBe(true);
     });
 
+    it("reachable HTTP errors do not fall through to local generation", async () => {
+      const llm = createLlm();
+      const ensureGenerateModel = spyOn(llm as any, "ensureGenerateModel").mockImplementation(
+        () => {
+          throw new Error("should not fall through to local generation");
+        }
+      );
+
+      globalThis.fetch = (() =>
+        Promise.resolve(new Response("Internal Server Error", { status: 500 }))
+      ) as any;
+
+      const result = await llm.generate("test prompt");
+      expect(result).toBeNull();
+      expect(ensureGenerateModel).not.toHaveBeenCalled();
+      ensureGenerateModel.mockRestore();
+    });
+
+    it("transport cooldown still logs once in remote-only mode", async () => {
+      const llm = createLlm();
+      process.env.CLAWMEM_NO_LOCAL_MODELS = "true";
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+      globalThis.fetch = (() => {
+        const err = new Error("connect ECONNREFUSED");
+        (err as any).code = "ECONNREFUSED";
+        throw err;
+      }) as any;
+
+      await llm.generate("test prompt");
+      await llm.generate("test prompt 2");
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("cooldown 60s");
+      warnSpy.mockRestore();
+    });
     it("AbortError does NOT trigger cooldown", async () => {
       const llm = createLlm();
       process.env.CLAWMEM_NO_LOCAL_MODELS = "true";

--- a/tests/unit/llm-fallback.test.ts
+++ b/tests/unit/llm-fallback.test.ts
@@ -351,6 +351,34 @@ describe("LLM Remote Fallback", () => {
       const result = await llm.embed("test 2");
       expect(fetchCalled).toBe(true);
     });
+
+    it("reachable HTTP embed errors do not fall through to local embedding", async () => {
+      const llm = createLlm();
+
+      const embedLocalSpy = spyOn(llm as any, "embedLocal").mockImplementation(async () => {
+        throw new Error("should not fall through to local embedding");
+      });
+      const embedLocalBatchSpy = spyOn(llm as any, "embedLocalBatch").mockImplementation(async () => {
+        throw new Error("should not fall through to local batch embedding");
+      });
+
+      globalThis.fetch = (() =>
+        Promise.resolve(new Response("Internal Server Error", { status: 500 }))
+      ) as any;
+
+      try {
+        const single = await llm.embed("test");
+        expect(single).toBeNull();
+        expect(embedLocalSpy).not.toHaveBeenCalled();
+
+        const batch = await llm.embedBatch(["a", "b"]);
+        expect(batch).toEqual([null, null]);
+        expect(embedLocalBatchSpy).not.toHaveBeenCalled();
+      } finally {
+        embedLocalSpy.mockRestore();
+        embedLocalBatchSpy.mockRestore();
+      }
+    });
   });
 
   // ─── Cross-service isolation ───────────────────────────────────────

--- a/tests/unit/memory.test.ts
+++ b/tests/unit/memory.test.ts
@@ -334,6 +334,42 @@ describe("applyCompositeScoring", () => {
     const scored = applyCompositeScoring([note, decision], "last session");
     expect(scored[0]!.contentType).toBe("decision");
   });
+
+  it("nudges canonical profile memory above same-score daily notes for stable-profile queries", () => {
+    const canonical = makeEnrichedResult({
+      displayPath: "pilot-memory/users/cooper.md",
+      filepath: "clawmem://pilot-memory/users/cooper.md",
+      title: "Cooper",
+      score: 0.7,
+    });
+    const daily = makeEnrichedResult({
+      displayPath: "pilot-memory/memory/2026-04-29.md",
+      filepath: "clawmem://pilot-memory/memory/2026-04-29.md",
+      title: "Daily",
+      score: 0.7,
+    });
+
+    const scored = applyCompositeScoring([daily, canonical], "What are Cooper's pronouns and timezone?");
+    expect(scored[0]!.displayPath).toBe("pilot-memory/users/cooper.md");
+  });
+
+  it("does not apply canonical profile nudge to recency-oriented queries", () => {
+    const canonical = makeEnrichedResult({
+      displayPath: "pilot-memory/users/cooper.md",
+      filepath: "clawmem://pilot-memory/users/cooper.md",
+      title: "Cooper",
+      score: 0.7,
+    });
+    const daily = makeEnrichedResult({
+      displayPath: "pilot-memory/memory/2026-04-29.md",
+      filepath: "clawmem://pilot-memory/memory/2026-04-29.md",
+      title: "Daily",
+      score: 0.71,
+    });
+
+    const scored = applyCompositeScoring([canonical, daily], "what happened today with Cooper?");
+    expect(scored[0]!.displayPath).toBe("pilot-memory/memory/2026-04-29.md");
+  });
 });
 
 // ─── New content types (v0.5.0) ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- avoid falling back to local embeddings on reachable remote HTTP/API errors, while keeping quieter localhost cooldown messaging for grammar expansion fallback
- add a narrow stable-profile ranking nudge so canonical profile/core memory can beat same-score daily notes without affecting recency-oriented queries
- make A-MEM link generation degrade cleanly when sqlite-vec/vector state is not ready yet

## Validation
- `bun test tests/unit/llm-fallback.test.ts tests/unit/amem.test.ts tests/unit/memory.test.ts`
- live pilot query sanity check: `clawmem query "What are Cooper's pronouns and timezone?" -n 5` returned `users/cooper.md` as the top result in the pilot corpus

## Notes
- I did not use `bunx tsc --noEmit` as the branch gate because the repo currently has unrelated pre-existing test typing failures in `tests/unit/maintenance.test.ts` and `tests/unit/normalize.test.ts`.
