### PR TITLE
fix(openclaw): shim __dirname for Node.js ESM plugin loader

### DIFF
--- a/src/openclaw/shell.ts
+++ b/src/openclaw/shell.ts
@@ -7,7 +7,15 @@
 
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ESM equivalent of CommonJS __dirname. This package declares
+// "type": "module", so __dirname is not defined when loaded by a plain
+// Node.js ESM loader (e.g. OpenClaw's plugin host). Bun shims __dirname
+// in ESM, which is why this regression is invisible under `bun test`.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // =============================================================================
 // Types


### PR DESCRIPTION
## What

Adds a `fileURLToPath`-based ESM shim for `__dirname` in `src/openclaw/shell.ts`, the only place in the OpenClaw plugin that still uses the CommonJS `__dirname` global.

## Why

`src/openclaw/package.json` declares `"type": "module"`, so when OpenClaw loads `dist/index.js` (which transitively imports `dist/shell.js`) via the **plain Node.js ESM loader**, the import fails at module evaluation:

```
ReferenceError: __dirname is not defined in ES module scope
This file is being treated as an ES module because it has a '.js'
file extension and '.../clawmem/package.json' contains "type": "module".
```

The plugin then fails to register, and any OpenClaw install that owns the memory slot via clawmem (`plugins.slots.memory: "clawmem"`) ends up with no active memory plugin:

```
[plugins] clawmem failed to load from .../extensions/clawmem/dist/index.js: ReferenceError: __dirname is not defined in ES module scope
[plugins] 1 plugin(s) failed to initialize (load: clawmem). Run 'openclaw plugins list' for details.
◇  Memory search ─────────────────────────────────────────────────╮
│  No active memory plugin is registered for the current config.  │
```

The bug is invisible under `bun test` because **Bun shims `__dirname` in ESM**, so the entire existing Bun-based test infra (`tests/unit/**`) passes against the buggy code. Plain Node — any modern version — reproduces it on first import.

Reproduces against `main` from a Node 20+ shell:

```bash
cd src/openclaw && bun run build
node --input-type=module -e "import('file://$(pwd)/dist/index.js').then(m => console.log('OK', Object.keys(m))).catch(e => console.error('FAIL', e.message))"
# FAIL ReferenceError: __dirname is not defined in ES module scope
```

After this patch:

```
OK [ 'default' ]
```

## How

`src/openclaw/shell.ts:37` reads `resolve(__dirname, "../../bin/clawmem")` to find the local bin during dev. Replace the bare `__dirname` reference with the canonical Node ESM shim:

```ts
import { dirname, resolve } from "node:path";
import { fileURLToPath } from "node:url";

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);
```

This is the documented Node.js workaround ([nodejs.org/api/esm.html#importmetaurl](https://nodejs.org/api/esm.html#importmetaurl)) and behaves identically under Bun, so:

- **Bun runtime:** unchanged. Bun's existing `__dirname` shim is overwritten by the local `const`, but it resolves to the same value (`fileURLToPath(import.meta.url)` is well-defined in Bun's ESM).
- **Node runtime:** module loads. `resolveClawMemBin()` now reaches the rest of the search-path fallbacks (`/usr/local/bin/clawmem`, `~/Projects/forge-stack/...`, `~/clawmem/bin/clawmem`, then `PATH`) instead of throwing before any path is tried.
- **Resolution behavior:** identical to the original intent. The path that was being computed (`<plugin>/dist/../../bin/clawmem` = `<plugin>/bin/clawmem`) is unchanged — we just stopped throwing before evaluating it.

Smoke-tested against `dist/shell.js` and `dist/index.js` after `bun run build`. Both load cleanly under Node 22 and Node 25.

## Testing

- [ ] Unit tests added/updated
- [x] All tests pass (`bun test`) — *unchanged; this code path is invisible to Bun (see Why)*
- [x] Manual testing done with `bin/clawmem` — *not applicable; this is a plugin-loader fix, not a CLI change. Manual repro done via `node --input-type=module` import smoke test described above.*

**Re: unit tests:** I considered adding a Bun unit test asserting `__dirname` is locally bound in `shell.ts`, but it would only enforce a textual pattern, not actual runtime behavior, since Bun cannot reproduce the bug. A more meaningful guard would be a Node-runtime smoke test in CI (`node --input-type=module -e "import('./dist/openclaw/index.js')..."`), but that's a CI infra change beyond this PR's "one concern" scope. Happy to follow up with a stacked PR adding that smoke test if you'd like — just say the word.

## Notes

Scoped strictly to `src/openclaw/shell.ts`. No other file uses `__dirname` or `__filename` in the package (verified with `rg '__dirname|__filename' src/openclaw`).

The original report came from an end-user OpenClaw install where this was the sole reason their memory slot wouldn't initialize — switching the slot to `active-memory` worked around it, but they wanted clawmem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
