### PR TITLE
fix: read reasoning_content as fallback for empty content in generate

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1049,12 +1049,15 @@ export class LlamaCpp implements LLM {
       }
 
       const data = await resp.json() as {
-        choices: { message: { content: string } }[];
+        choices: { message: { content?: string; reasoning_content?: string } }[];
         model?: string;
       };
 
+      const msg = data.choices[0]?.message;
+      const text = msg?.content || msg?.reasoning_content || "";
+
       return {
-        text: data.choices[0]?.message?.content || "",
+        text,
         model: data.model || this.remoteLlmUrl!,
         done: true,
       };


### PR DESCRIPTION
## Problem

Some models (e.g. GLM-4.5-flash with /no_think) return an empty `content` field and put the actual response in `reasoning_content`. ClawMem only reads `content`, resulting in empty generate results.

## Change

Reads `reasoning_content` as fallback when `content` is empty in `generateRemote()`.

## Testing

Verified: GLM-4.5-flash now returns actual text via reasoning_content instead of empty string.