### PR TITLE
fix: allow full chat/completions URL without /v1 appending

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -290,6 +290,7 @@ function normalizeRemoteLlmReasoningEffort(value?: string): string | null {
 
 function buildRemoteChatCompletionsUrl(remoteLlmUrl: string): string {
   const baseUrl = remoteLlmUrl.replace(/\/+$/, "");
+  if (baseUrl.endsWith("/chat/completions")) return baseUrl;
   const endpoint = baseUrl.endsWith("/v1") ? "/chat/completions" : "/v1/chat/completions";
   return `${baseUrl}${endpoint}`;
 }


### PR DESCRIPTION
## Problem

Some LLM API endpoints use non-standard paths (e.g. z.ai uses /v4/chat/completions).
buildRemoteChatCompletionsUrl always appends /v1/chat/completions, causing 404.

## Change

If the URL already ends with /chat/completions, return it as-is instead of
appending /v1/chat/completions.

## Testing

z.ai endpoint now resolves correctly: /v4/chat/completions → 200 (was 404).